### PR TITLE
修复setInc / setDec 方法不能正常工作问题

### DIFF
--- a/src/db/Query.php
+++ b/src/db/Query.php
@@ -588,7 +588,7 @@ class Query
      */
     public function setInc($field, $step = 1)
     {
-        return $this->setField($field, ['exp', $field, $step]);
+        return $this->setField($field, ['inc', $field, $step]);
     }
 
     /**
@@ -601,7 +601,7 @@ class Query
      */
     public function setDec($field, $step = 1)
     {
-        return $this->setField($field, ['exp', $field, $step]);
+        return $this->setField($field, ['dec', $field, $step]);
     }
 
     /**


### PR DESCRIPTION
修改前，使用的是exp关键字，导致生成的SQL语句为：
```sql
UPDATE `users`  SET `points`=points  WHERE  `id` = 1
```
  