### PR TITLE
hasMany调用saveAll 无法找到replace

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -343,6 +343,18 @@ abstract class Model implements \JsonSerializable, \ArrayAccess
     }
 
     /**
+     * 新增数据是否使用Replace
+     * @access public
+     * @param  bool $replace
+     * @return $this
+     */
+    public function replace($replace = true)
+    {
+        $this->replace = $replace;
+        return $this;
+    }
+
+    /**
      * 设置数据是否存在
      * @access public
      * @param  bool $exists


### PR DESCRIPTION
hasMany调用saveAll 无法找到replace
使用一对多时,使用saveAll 会提示replace方法无法找到

查看源码
think\model\relation\HasMany
在第238行调用了model的replace方法
return $model->replace($replace)->save($data) ? $model : false;