### PR TITLE
strtoupper前增加is_string判断

### DIFF
--- a/src/db/concern/WhereQuery.php
+++ b/src/db/concern/WhereQuery.php
@@ -429,7 +429,7 @@ trait WhereQuery
                 // 字段相等查询
                 $where = $this->whereEq($field, $op);
             }
-        } elseif (in_array(strtoupper($op), ['EXISTS', 'NOT EXISTS', 'NOTEXISTS'], true)) {
+        } elseif (is_string($op) && in_array(strtoupper($op), ['EXISTS', 'NOT EXISTS', 'NOTEXISTS'], true)) {
             $where = [$field, $op, is_string($condition) ? new Raw($condition) : $condition];
         } else {
             $where = $field ? [$field, $op, $condition, $param[2] ?? null] : [];


### PR DESCRIPTION
**strtoupper() expects parameter 1 to be string 错误**

当`WhereQuery::where`传入一个空字符串时，`WhereQuery::parseWhereItem`的参数$op=null，此时，如果进入`in_array(strtoupper($op), ['EXISTS', 'NOT EXISTS', 'NOTEXISTS'], true)`的判断，strtoupper($op) 为strtoupper(null)，出现错误：
`PHP Fatal error:  Uncaught TypeError: strtoupper() expects parameter 1 to be string, null given`

在strtoupper($op)前，应进行确保$op为string类型