### PR TITLE
修复 setCurrentPage 导致的分页传参计算错误

### DIFF
--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -112,13 +112,13 @@ abstract class Paginator implements ArrayAccess, Countable, IteratorAggregate, J
         }
 
         if ($simple) {
-            $this->currentPage = $this->setCurrentPage($currentPage);
+            $this->currentPage = $currentPage;
             $this->hasMore     = count($items) > ($this->listRows);
             $items             = $items->slice(0, $this->listRows);
         } else {
             $this->total       = $total;
             $this->lastPage    = (int) ceil($total / $listRows);
-            $this->currentPage = $this->setCurrentPage($currentPage);
+            $this->currentPage = $currentPage;
             $this->hasMore     = $this->currentPage < $this->lastPage;
         }
         $this->items = $items;
@@ -146,15 +146,6 @@ abstract class Paginator implements ArrayAccess, Countable, IteratorAggregate, J
     public static function maker(Closure $resolver)
     {
         static::$maker = $resolver;
-    }
-
-    protected function setCurrentPage(int $currentPage): int
-    {
-        if (!$this->simple && $currentPage > $this->lastPage) {
-            return $this->lastPage > 0 ? $this->lastPage : 1;
-        }
-
-        return $currentPage;
     }
 
     /**


### PR DESCRIPTION
设置分页页码不应该强制根据 `lastPage`强制设置 当前页为第一页
当分页查询的数据是空值时，无论如何改变 `page` (query)参数，`currentPage `都会是1，这不利于前端的使用

该 `pr` 将删除以下代码
```
if (!$this->simple && $currentPage > $this->lastPage) {
    return $this->lastPage > 0 ? $this->lastPage : 1;
}
```