### PR TITLE
完善一处PHP7.4兼容性问题

### DIFF
--- a/src/model/Relation.php
+++ b/src/model/Relation.php
@@ -228,7 +228,7 @@ abstract class Relation
 
         if (!empty($params)) {
             $type = $params[0]->getType();
-            return Relation::class == $type || is_null($type) ? $this : $this->query;
+            return is_null($type) || Relation::class == $type->getName() ? $this : $this->query;
         }
 
         return $this;


### PR DESCRIPTION
Function ReflectionType::__toString() is deprecated
`Relation::class`为字符型，与`$type`比较时，会触发`__toString()`