### PR TITLE
[2.0.31] fix: where空闭包导致生成语句错误

### DIFF
--- a/src/db/Builder.php
+++ b/src/db/Builder.php
@@ -368,7 +368,10 @@ abstract class Builder
 
             if ($value instanceof Closure) {
                 // 使用闭包查询
-                $where[] = $this->parseClosureWhere($query, $value, $logic);
+                $whereClosureStr = $this->parseClosureWhere($query, $value, $logic);
+                if ($whereClosureStr) {
+                    $where[] = $whereClosureStr;
+                }
             } elseif (is_array($field)) {
                 $where[] = $this->parseMultiWhereField($query, $value, $field, $logic, $binds);
             } elseif ($field instanceof Raw) {


### PR DESCRIPTION
where 使用闭包查询，当闭包内为没有有效的where语句时将导致生成sql错误

原因：
- parseClosureWhere 解析空闭包返回空字符串
- buildWhere 拼接带有空字符串的数组时支字符串前面会多一个空格，导致 substr 切割错位

正确的语句：
```
SELECT COUNT(*) AS think_count FROM `user_account` WHERE (  `ID` IN (SELECT `ID` FROM `user_account` WHERE  ( `user_name` = 'xxxxxxx' OR `user_as_name` = 'xxxxxxx' )) ) AND `user_account`.`recover` = 0
```

错误的语句：
AND 的残留了个 D 
```
SELECT COUNT(*) AS think_count FROM `user_account` WHERE ( D `ID` IN (SELECT `ID` FROM `user_account` WHERE  ( `user_name` = 'xxxxxxx' OR `user_as_name` = 'xxxxxxx' )) ) AND `user_account`.`recover` = 0
```

