### PR TITLE
[2.0.31] fix: SoftDelete::destroy() 真实删除无效

### DIFF
--- a/src/model/concern/SoftDelete.php
+++ b/src/model/concern/SoftDelete.php
@@ -13,9 +13,11 @@ declare (strict_types = 1);
 namespace think\model\concern;
 
 use think\db\BaseQuery as Query;
+use think\Model;
 
 /**
  * 数据软删除
+ * @mixin Model
  */
 trait SoftDelete
 {
@@ -149,7 +151,7 @@ trait SoftDelete
     public static function destroy($data, bool $force = false): bool
     {
         // 包含软删除数据
-        $query = (new static())->db(false);
+        $query = (new static())->withTrashedData(true)->db(false);
 
         if (is_array($data) && key($data) !== 0) {
             $query->where($data);


### PR DESCRIPTION
withTrashed没有设置无法查出数据，导致`Model::destroy($id, true)`无效。

close #136 