### PR TITLE
改进追加关联对象属性

### DIFF
--- a/src/model/concern/Conversion.php
+++ b/src/model/concern/Conversion.php
@@ -195,8 +195,14 @@ trait Conversion
             [$key, $attr] = explode('.', $name);
             // 追加关联对象属性
             $relation   = $this->getRelation($key, true);
-            $item[$key] = $relation ? $relation->append([$attr])
+            $data = $relation ? $relation->append([$attr])
                 ->toArray() : [];
+            
+            if (array_key_exists($key, $item)) {
+                $item[$key] = array_merge($item[$key], $data);
+            } else {
+                $item[$key] = $data;
+            }
         } else {
             $value       = $this->getAttr($name);
             $item[$name] = $value;


### PR DESCRIPTION
使用下列方法追加两个关联属性时，最终只会追加到`sex_text`，`status_text`被覆盖了。两个关联属性均为定义的获取器。
```
$user = User::find(1);
dump($user->append(['profile.status_text', 'profile.sex_text'])->toArray());
```