### PR TITLE
修复数据值是null时,只读判断失效

### DIFF
--- a/src/model/concern/Attribute.php
+++ b/src/model/concern/Attribute.php
@@ -280,7 +280,7 @@ trait Attribute
         if (!empty($this->readonly)) {
             // 只读字段不允许更新
             foreach ($this->readonly as $key => $field) {
-                if (isset($data[$field])) {
+                if (array_key_exists($field, $data)) {
                     unset($data[$field]);
                 }
             }


### PR DESCRIPTION
`isset`判断字段值是否是`null`，无法判断数组的键名是否存在。如果更新的字段存在，并且是`null`，只读判断失效就会失效，导致数据库数据被null覆盖。

```
$arr = [
   'key' => null
];

isset($arr['key']); // false
```