### PR TITLE
一对一关联支持order排序

### DIFF
--- a/src/model/relation/OneToOne.php
+++ b/src/model/relation/OneToOne.php
@@ -308,7 +308,7 @@ abstract class OneToOne extends Relation
         }
 
         if ($this->query->getOptions('order')) {
-            $this->query->group($key);
+            $this->query->order($this->query->getOptions('order'));
         }
 
         $list = $this->query


### PR DESCRIPTION
现有的增加排序后直接调用 group方法 无法获取最新的一条数据进行一对一关联输出