### PR TITLE
空字符串解决

### DIFF
--- a/src/model/concern/SoftDelete.php
+++ b/src/model/concern/SoftDelete.php
@@ -159,7 +159,7 @@ trait SoftDelete
         } elseif ($data instanceof \Closure) {
             call_user_func_array($data, [ & $query]);
             $data = null;
-        } elseif (is_null($data)) {
+        } elseif (is_null($data) ||empty($data) ) {
             return false;
         }
 


### PR DESCRIPTION
destroy方法传入空字符串的时候会进行查询和与实际目的不想关的性能损失，所以直接在前面加入判断，防止后面进行查询操作，并给用户返回flase而不是true，方便用户找出错误