### PR TITLE
数字和数字字符串不使用恒等于进行判断

### DIFF
--- a/src/model/concern/Attribute.php
+++ b/src/model/concern/Attribute.php
@@ -292,12 +292,12 @@ trait Attribute
      */
     public function getChangedData(): array
     {
-        $data = $this->force ? $this->data : array_udiff_assoc($this->data, $this->origin, function ($a, $b) {
-            if ((empty($a) || empty($b)) && $a !== $b) {
+        $data = $this->force ? $this->data : array_udiff_assoc($this->data, $this->origin, function ($new, $origin) {
+            if ((empty($new) || empty($origin)) && !is_numeric($origin) && $new !== $origin) {
                 return 1;
             }
 
-            return is_object($a) || $a != $b ? 1 : 0;
+            return is_object($new) || $new != $origin ? 1 : 0;
         });
 
         // 只读字段不允许更新


### PR DESCRIPTION
数据库字段类型为`int`/`decimal`/`float`，用户输入变量一般为字符型。这样的情况下，数据库的值或用户输入变量为0时，会使用恒等于判断（`'0' !== 0`），认定为数据有变更。但实际更新到数据库时，数据是没有变化的，框架生成SQL语句时会自动识别字段类型，SQL中的用户输入变量为常量。