### PR TITLE
修复命令行生成数据库字段缓存为空的bug

### DIFF
--- a/src/db/connector/Sqlsrv.php
+++ b/src/db/connector/Sqlsrv.php
@@ -56,7 +56,7 @@ class Sqlsrv extends PDOConnection
     public function getFields(string $tableName): array
     {
         [$tableName] = explode(' ', $tableName);
-
+        strpos($tableName,'.') && $tableName = substr($tableName,strpos($tableName,'.') + 1);
         $sql = "SELECT   column_name,   data_type,   column_default,   is_nullable
         FROM    information_schema.tables AS t
         JOIN    information_schema.columns AS c


### PR DESCRIPTION
命令行生成字段缓存会生成为空，获取不到字段信息