### PR TITLE
修复模型 column 方法只有 field 字段传 '*' 时返回空数组

### DIFF
--- a/src/db/PDOConnection.php
+++ b/src/db/PDOConnection.php
@@ -1191,7 +1191,7 @@ abstract class PDOConnection extends Connection
                 $key = null;
             }
 
-            if (strpos($column, ',')) {
+            if ('*' == $column || strpos($column, ',')) {
                 $column = null;
             } elseif (strpos($column, ' ')) {
                 $column = substr(strrchr(trim($column), ' '), 1);


### PR DESCRIPTION
修复模型 column 方法只有 field 字段传 '*' 时返回空数组