### PR TITLE
增强 column 功能，支持完整的 field() 字段定义

### DIFF
--- a/src/db/BaseQuery.php
+++ b/src/db/BaseQuery.php
@@ -266,11 +266,11 @@ abstract class BaseQuery
     /**
      * 得到某个列的数组
      * @access public
-     * @param string $field 字段名 多个字段用逗号分隔
+     * @param string|array $field 字段名 多个字段用逗号分隔
      * @param string $key   索引
      * @return array
      */
-    public function column(string $field, string $key = ''): array
+    public function column($field, string $key = ''): array
     {
         return $this->connection->column($this, $field, $key);
     }

--- a/src/db/ConnectionInterface.php
+++ b/src/db/ConnectionInterface.php
@@ -145,11 +145,11 @@ interface ConnectionInterface
      * 得到某个列的数组
      * @access public
      * @param BaseQuery  $query  查询对象
-     * @param string $column 字段名 多个字段用逗号分隔
+     * @param string|array $column 字段名 多个字段用逗号分隔
      * @param string $key    索引
      * @return array
      */
-    public function column(BaseQuery $query, string $column, string $key = ''): array;
+    public function column(BaseQuery $query, $column, string $key = ''): array;
 
     /**
      * 执行数据库事务

--- a/src/db/connector/Mongo.php
+++ b/src/db/connector/Mongo.php
@@ -29,6 +29,8 @@ use think\db\builder\Mongo as Builder;
 use think\db\Connection;
 use think\db\exception\DbException as Exception;
 use think\db\Mongo as Query;
+use function implode;
+use function is_array;
 
 /**
  * Mongo数据库驱动
@@ -969,11 +971,12 @@ class Mongo extends Connection
     /**
      * 得到某个列的数组
      * @access public
-     * @param  string $field 字段名 多个字段用逗号分隔
-     * @param  string $key 索引
+     * @param BaseQuery    $query
+     * @param string|array $field 字段名 多个字段用逗号分隔
+     * @param string       $key   索引
      * @return array
      */
-    public function column(BaseQuery $query, string $field, string $key = ''): array
+    public function column(BaseQuery $query, $field, string $key = ''): array
     {
         $options = $query->parseOptions();
 
@@ -981,6 +984,9 @@ class Mongo extends Connection
             $query->removeOption('projection');
         }
 
+        if (is_array($field)) {
+            $field = implode(',', $field);
+        }
         if ($key && '*' != $field) {
             $projection = $key . ',' . $field;
         } else {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/functions.php';
 
 use think\facade\Db;
 // 数据库配置信息设置（全局有效）

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace tests;
+
+use function array_column;
+use function array_combine;
+use function array_map;
+use function sort;
+
+function array_column_ex(array $arr, array $column, ?string $key = null): array
+{
+    $result = array_map(function ($val) use ($column) {
+        $item = [];
+        foreach ($column as $key) {
+            $item[$key] = $val[$key];
+        }
+        return $item;
+    }, $arr);
+
+    if (!empty($key)) {
+        $result = array_combine(array_column($arr, 'id'), $result);
+    }
+
+    return $result;
+}
+
+function array_value_sort(array $arr)
+{
+    foreach ($arr as &$value) {
+        sort($value);
+    }
+}

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -5,14 +5,23 @@ namespace tests;
 use function array_column;
 use function array_combine;
 use function array_map;
+use function call_user_func;
+use function is_callable;
+use function is_int;
 use function sort;
 
 function array_column_ex(array $arr, array $column, ?string $key = null): array
 {
     $result = array_map(function ($val) use ($column) {
         $item = [];
-        foreach ($column as $key) {
-            $item[$key] = $val[$key];
+        foreach ($column as $index => $key) {
+            if (is_callable($key)) {
+                $item[$index] = call_user_func($key, $val);
+            } elseif (is_int($index)) {
+                $item[$key] = $val[$key];
+            } else {
+                $item[$key] = $val[$index];
+            }
         }
         return $item;
     }, $arr);

--- a/tests/orm/DbTest.php
+++ b/tests/orm/DbTest.php
@@ -8,6 +8,7 @@ use think\facade\Db;
 use function array_column;
 use function array_keys;
 use function array_values;
+use function tests\array_column_ex;
 
 class DbTest extends TestCase
 {
@@ -26,24 +27,34 @@ SQL
         );
     }
 
+
+
     public function testColumn()
     {
         Db::execute('TRUNCATE TABLE `test_user`;');
         $users = [
-            ['id' => '1', 'type' => '3', 'username' => 'qweqwe', 'nickname' => 'asdasd', 'password' => '123123'],
-            ['id' => '2', 'type' => '2', 'username' => 'rtyrty', 'nickname' => 'fghfgh', 'password' => '456456'],
-            ['id' => '3', 'type' => '1', 'username' => 'uiouio', 'nickname' => 'jkljkl', 'password' => '789789'],
+            ['id' => 1, 'type' => 3, 'username' => 'qweqwe', 'nickname' => 'asdasd', 'password' => '123123'],
+            ['id' => 2, 'type' => 2, 'username' => 'rtyrty', 'nickname' => 'fghfgh', 'password' => '456456'],
+            ['id' => 3, 'type' => 1, 'username' => 'uiouio', 'nickname' => 'jkljkl', 'password' => '789789'],
+            ['id' => 5, 'type' => 2, 'username' => 'qazqaz', 'nickname' => 'wsxwsx', 'password' => '098098'],
+            ['id' => 7, 'type' => 2, 'username' => 'rfvrfv', 'nickname' => 'tgbtgb', 'password' => '765765'],
         ];
 
+        // 获取全部列
         Db::table('test_user')->insertAll($users);
         $result = Db::table('test_user')->column('*', 'id');
 
-        $this->assertCount(3, $result);
+        $this->assertCount(5, $result);
         $this->assertEquals($users, array_values($result));
         $this->assertEquals(array_column($users, 'id'), array_keys($result));
 
+        // 获取某一个字段
         $result = Db::table('test_user')->column('username');
-
         $this->assertEquals(array_column($users, 'username'), $result);
+
+        // 获取若干列
+        $result = Db::table('test_user')->column('username,nickname', 'id');
+        $expected = array_column_ex($users, ['username', 'nickname', 'id'], 'id');
+        $this->assertEquals($expected, $result);
     }
 }


### PR DESCRIPTION
1. 修正获取多个字段但不传递key时报错问题。
```
TypeError : strpos() expects parameter 1 to be string, null given
 /home/vagrant/code/thinkphp/think-orm/src/db/PDOConnection.php:1200
 /home/vagrant/code/thinkphp/think-orm/src/db/BaseQuery.php:275
 /home/vagrant/code/thinkphp/think-orm/tests/orm/DbTest.php:57
```
2. 简化函数实现。
3. 支持数组定义、Raw表达式、别名定义等`field`原有功能。
4. 由于不熟系`mongo`，暂不改变其的代码实现


原实现对的 `alias` 和 `.` 的处理未找文档和出处，故简化掉。
@liu21st 看看是否有什么问题？