### PR TITLE
增加获取器场景功能

### DIFF
--- a/src/model/Collection.php
+++ b/src/model/Collection.php
@@ -118,6 +118,21 @@ class Collection extends BaseCollection
     }
 
     /**
+     * 根据追加场景设置需要附加的输出属性
+     * @access public
+     * @param  string $scene   追加场景名称
+     * @return $this
+     */
+    public function appendByScene(string $scene = '')
+    {
+        $this->each(function (Model $model) use ($scene) {
+            $model->appendByScene($scene);
+        });
+
+        return $this;
+    }
+
+    /**
      * 设置父模型
      * @access public
      * @param  Model $parent 父模型

--- a/src/model/concern/Attribute.php
+++ b/src/model/concern/Attribute.php
@@ -95,6 +95,12 @@ trait Attribute
     protected $strict = true;
 
     /**
+     * 获取器场景 [sceneFilter:string => appendFieldNotInTable[]][]
+     * @var array
+     */
+    protected $appendsScene = [];
+
+    /**
      * 修改器执行记录
      * @var array
      */
@@ -676,6 +682,18 @@ trait Attribute
         }
 
         return $this;
+    }
+
+    /**
+     * 获取场景下的获取器字段
+     * @access public
+     * @param string $scene
+     * @return array|mixed
+     */
+    public function getAppendsFieldsByScene(string $scene = ''):array
+    {
+        $scene = empty($scene) ? 'default' : $scene;
+        return $this->appendsScene[$scene] ?? [];
     }
 
 }

--- a/src/model/concern/Conversion.php
+++ b/src/model/concern/Conversion.php
@@ -80,8 +80,21 @@ trait Conversion
      */
     public function append(array $append = [])
     {
-        $this->append = $append;
+        $this->append = array_unique(array_merge($this->append,$append));
 
+        return $this;
+    }
+
+    /**
+     * 根据追加场景设置需要附加的输出属性
+     * @access public
+     * @param  string $scene   追加场景名称
+     * @return $this
+     */
+    public function appendByScene(string $scene = '')
+    {
+        $appends = $this->getAppendsFieldsByScene($scene);
+        $this->append($appends);
         return $this;
     }
 


### PR DESCRIPTION
### 增加模型设置获取器场景的功能

#### 使用方法

1.在模型中配置`$appendsScene`属性，如：

```
protected $appendsScene = [
        'default'=>['gender_text','avatar_full_path'],
        'list'=>['gender_text']
    ];
```

2.通过模型查询数据后，可以通过`appendByScene(string $scene = '')`来根据场景追加获取器

```
// case one
$profile = User::find(1);
$profile->appendByScene()->toArray();

// case two
$userList = User::select();
$userList->appendByScene('list')->toArray();
```