### PR TITLE
where In 空数组查询改进

### DIFF
--- a/src/db/Builder.php
+++ b/src/db/Builder.php
@@ -15,6 +15,7 @@ namespace think\db;
 use Closure;
 use PDO;
 use think\db\exception\DbException as Exception;
+use function count;
 
 /**
  * Db Builder
@@ -490,7 +491,7 @@ abstract class Builder
         // 字段分析
         $key = $field ? $this->parseKey($query, $field, true) : '';
 
-        list($exp, $value) = $val;
+        [$exp, $value] = $val;
 
         // 检测操作符
         if (!is_string($exp)) {
@@ -756,6 +757,9 @@ abstract class Builder
             $value = $this->parseRaw($query, $value);
         } else {
             $value = array_unique(is_array($value) ? $value : explode(',', $value));
+            if (count($value) === 0) {
+                return '0 = 1';
+            }
             $array = [];
 
             foreach ($value as $v) {
@@ -766,8 +770,7 @@ abstract class Builder
             if (count($array) == 1) {
                 return $key . ('IN' == $exp ? ' = ' : ' <> ') . $array[0];
             } else {
-                $zone  = implode(',', $array);
-                $value = empty($zone) ? "''" : $zone;
+                $value  = implode(',', $array);
             }
         }
 
@@ -898,7 +901,7 @@ abstract class Builder
                 $array[] = $this->parseRand($query);
             } elseif (is_string($val)) {
                 if (is_numeric($key)) {
-                    list($key, $sort) = explode(' ', strpos($val, ' ') ? $val : $val . ' ');
+                    [$key, $sort] = explode(' ', strpos($val, ' ') ? $val : $val . ' ');
                 } else {
                     $sort = $val;
                 }

--- a/tests/orm/DbTest.php
+++ b/tests/orm/DbTest.php
@@ -137,13 +137,18 @@ SQL
         $result = Db::table('test_user')->whereIn('type', [1])->column('*');
         $this->assertEquals($expected, $result);
 
+        $expected = Collection::make(self::$testUserData)->whereIn('type', [1, ''])->values()->toArray();
+        $result = Db::table('test_user')->whereIn('type', [1, ''])->column('*');
+        $this->assertEquals($expected, $result);
+
         $result = Db::table('test_user')->whereIn('type', [])->column('*');
         $this->assertEquals([], $result);
 
         $this->assertEquals([
             "SELECT * FROM `test_user` WHERE  `type` IN (1,3)",
             "SELECT * FROM `test_user` WHERE  `type` = 1",
-            "SELECT * FROM `test_user` WHERE  `type` IN ('')",
+            "SELECT * FROM `test_user` WHERE  `type` IN (1,0)",
+            "SELECT * FROM `test_user` WHERE  0 = 1",
         ], $sqlLogs);
     }
 }


### PR DESCRIPTION
closes #225 

可能产生的问题：假设字段值存在空字符串的情况下这个更改会导致兼容性问题

相关参考：https://github.com/typeorm/typeorm/pull/6887