### PR TITLE
改进事务中的断连重试处理，避免造成数据污染

### DIFF
--- a/src/db/PDOConnection.php
+++ b/src/db/PDOConnection.php
@@ -18,6 +18,7 @@ use PDOStatement;
 use think\db\exception\BindParamException;
 use think\db\exception\DbException;
 use think\db\exception\PDOException;
+use think\Model;
 
 /**
  * 数据库连接基础类
@@ -169,6 +170,26 @@ abstract class PDOConnection extends Connection
         'Error writing data to the connection',
         'Resource deadlock avoided',
         'failed with errno',
+        'child connection forced to terminate due to client_idle_limit',
+        'query_wait_timeout',
+        'reset by peer',
+        'Physical connection is not usable',
+        'TCP Provider: Error code 0x68',
+        'ORA-03114',
+        'Packets out of order. Expected',
+        'Adaptive Server connection failed',
+        'Communication link failure',
+        'connection is no longer usable',
+        'Login timeout expired',
+        'SQLSTATE[HY000] [2002] Connection refused',
+        'running with the --read-only option so it cannot execute this statement',
+        'The connection is broken and recovery is not possible. The connection is marked by the client driver as unrecoverable. No attempt was made to restore the connection.',
+        'SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed: Try again',
+        'SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo failed: Name or service not known',
+        'SQLSTATE[HY000]: General error: 7 SSL SYSCALL error: EOF detected',
+        'SQLSTATE[HY000] [2002] Connection timed out',
+        'SSL: Connection timed out',
+        'SQLSTATE[HY000]: General error: 1105 The last transaction was aborted due to Seamless Scaling. Please retry.',
     ];
 
     /**
@@ -580,7 +601,7 @@ abstract class PDOConnection extends Connection
     /**
      * 获取PDO对象
      * @access public
-     * @return \PDO|false
+     * @return PDO|false
      */
     public function getPdo()
     {
@@ -594,12 +615,13 @@ abstract class PDOConnection extends Connection
     /**
      * 执行查询 使用生成器返回数据
      * @access public
-     * @param BaseQuery    $query     查询对象
-     * @param string       $sql       sql指令
-     * @param array        $bind      参数绑定
-     * @param \think\Model $model     模型对象实例
-     * @param array        $condition 查询条件
+     * @param BaseQuery  $query     查询对象
+     * @param string     $sql       sql指令
+     * @param array      $bind      参数绑定
+     * @param Model|null $model     模型对象实例
+     * @param null       $condition 查询条件
      * @return \Generator
+     * @throws DbException
      */
     public function getCursor(BaseQuery $query, string $sql, array $bind = [], $model = null, $condition = null)
     {
@@ -618,12 +640,11 @@ abstract class PDOConnection extends Connection
     /**
      * 执行查询 返回数据集
      * @access public
-     * @param string $sql  sql指令
-     * @param array  $bind 参数绑定
+     * @param string $sql    sql指令
+     * @param array  $bind   参数绑定
      * @param bool   $master 主库读取
      * @return array
-     * @throws BindParamException
-     * @throws \PDOException
+     * @throws DbException
      */
     public function query(string $sql, array $bind = [], bool $master = false): array
     {
@@ -636,8 +657,7 @@ abstract class PDOConnection extends Connection
      * @param string $sql  sql指令
      * @param array  $bind 参数绑定
      * @return int
-     * @throws BindParamException
-     * @throws \PDOException
+     * @throws DbException
      */
     public function execute(string $sql, array $bind = []): int
     {
@@ -647,15 +667,12 @@ abstract class PDOConnection extends Connection
     /**
      * 执行查询 返回数据集
      * @access protected
-     * @param BaseQuery $query 查询对象
-     * @param mixed     $sql   sql指令
-     * @param array     $bind  参数绑定
+     * @param BaseQuery $query  查询对象
+     * @param mixed     $sql    sql指令
+     * @param array     $bind   参数绑定
      * @param bool      $master 主库读取
      * @return array
-     * @throws BindParamException
-     * @throws \PDOException
-     * @throws \Exception
-     * @throws \Throwable
+     * @throws DbException
      */
     protected function pdoQuery(BaseQuery $query, $sql, array $bind = [], bool $master = null): array
     {
@@ -703,6 +720,7 @@ abstract class PDOConnection extends Connection
      * @access public
      * @param BaseQuery $query 查询对象
      * @return \PDOStatement
+     * @throws DbException
      */
     public function pdo(BaseQuery $query): PDOStatement
     {
@@ -721,10 +739,7 @@ abstract class PDOConnection extends Connection
      * @param bool   $master    是否在主服务器读操作
      * @param bool   $procedure 是否为存储过程调用
      * @return PDOStatement
-     * @throws BindParamException
-     * @throws \PDOException
-     * @throws \Exception
-     * @throws \Throwable
+     * @throws DbException
      */
     public function getPDOStatement(string $sql, array $bind = [], bool $master = false, bool $procedure = false): PDOStatement
     {
@@ -758,17 +773,19 @@ abstract class PDOConnection extends Connection
             $this->reConnectTimes = 0;
 
             return $this->PDOStatement;
-        } catch (\Throwable | \Exception $e) {
-            if ($this->reConnectTimes < 4 && $this->isBreak($e)) {
-                ++$this->reConnectTimes;
-                return $this->close()->getPDOStatement($sql, $bind, $master, $procedure);
+        } catch (\PDOException $e) {
+            if ($this->transTimes > 0) {
+                // 事务活动中时不应该进行重试，应直接中断执行，防止造成污染。
+                $this->transTimes = 0;
+                $this->reConnectTimes = 0;
+            } else {
+                if ($this->reConnectTimes < 4 && $this->isBreak($e)) {
+                    ++$this->reConnectTimes;
+                    return $this->close()->getPDOStatement($sql, $bind, $master, $procedure);
+                }
             }
 
-            if ($e instanceof \PDOException) {
-                throw new PDOException($e, $this->config, $this->getLastsql());
-            } else {
-                throw $e;
-            }
+            throw new PDOException($e, $this->config, $this->getLastsql());
         }
     }
 
@@ -780,10 +797,7 @@ abstract class PDOConnection extends Connection
      * @param array     $bind   参数绑定
      * @param bool      $origin 是否原生查询
      * @return int
-     * @throws BindParamException
-     * @throws \PDOException
-     * @throws \Exception
-     * @throws \Throwable
+     * @throws DbException
      */
     protected function pdoExecute(BaseQuery $query, string $sql, array $bind = [], bool $origin = false): int
     {
@@ -815,6 +829,13 @@ abstract class PDOConnection extends Connection
         return $this->numRows;
     }
 
+    /**
+     * @param BaseQuery $query
+     * @param string    $sql
+     * @param array     $bind
+     * @return PDOStatement
+     * @throws DbException
+     */
     protected function queryPDOStatement(BaseQuery $query, string $sql, array $bind = []): PDOStatement
     {
         $options   = $query->getOptions();
@@ -1416,12 +1437,13 @@ abstract class PDOConnection extends Connection
                 );
             }
             $this->reConnectTimes = 0;
-        } catch (\Exception $e) {
-            if ($this->reConnectTimes < 4 && $this->isBreak($e)) {
+        } catch (\PDOException $e) {
+            if ($this->transTimes === 1 && $this->reConnectTimes < 4 && $this->isBreak($e)) {
                 --$this->transTimes;
                 ++$this->reConnectTimes;
                 $this->close()->startTrans();
             } else {
+                $this->transTimes = 0;
                 throw $e;
             }
         }
@@ -1535,6 +1557,7 @@ abstract class PDOConnection extends Connection
         $this->linkWrite = null;
         $this->linkRead  = null;
         $this->links     = [];
+        $this->transTimes = 0;
 
         $this->free();
 

--- a/src/db/PDOConnection.php
+++ b/src/db/PDOConnection.php
@@ -773,11 +773,13 @@ abstract class PDOConnection extends Connection
             $this->reConnectTimes = 0;
 
             return $this->PDOStatement;
-        } catch (\PDOException $e) {
+        } catch (\Throwable | \Exception $e) {
             if ($this->transTimes > 0) {
                 // 事务活动中时不应该进行重试，应直接中断执行，防止造成污染。
-                $this->transTimes = 0;
-                $this->reConnectTimes = 0;
+                if ($this->isBreak($e)) {
+                    // 尝试对事务计数进行重置
+                    $this->transTimes = 0;
+                }
             } else {
                 if ($this->reConnectTimes < 4 && $this->isBreak($e)) {
                     ++$this->reConnectTimes;
@@ -785,7 +787,11 @@ abstract class PDOConnection extends Connection
                 }
             }
 
-            throw new PDOException($e, $this->config, $this->getLastsql());
+            if ($e instanceof \PDOException) {
+                throw new PDOException($e, $this->config, $this->getLastsql());
+            } else {
+                throw $e;
+            }
         }
     }
 
@@ -1437,13 +1443,16 @@ abstract class PDOConnection extends Connection
                 );
             }
             $this->reConnectTimes = 0;
-        } catch (\PDOException $e) {
+        } catch (\Throwable | \Exception $e) {
             if ($this->transTimes === 1 && $this->reConnectTimes < 4 && $this->isBreak($e)) {
                 --$this->transTimes;
                 ++$this->reConnectTimes;
                 $this->close()->startTrans();
             } else {
-                $this->transTimes = 0;
+                if ($this->isBreak($e)) {
+                    // 尝试对事务计数进行重置
+                    $this->transTimes = 0;
+                }
                 throw $e;
             }
         }

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace tests;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\Version;
+use function version_compare;
+
+class Base extends TestCase
+{
+    protected function proxyAssertMatchesRegularExpression(string $pattern, string $string, string $message = '')
+    {
+        if (version_compare(Version::id(), '9.1', '>=')) {
+            $this->assertMatchesRegularExpression($pattern, $string, $message);
+        } else {
+            $this->assertRegExp($pattern, $string, $message);
+        }
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,6 +24,28 @@ Db::setConfig([
             'charset'  => 'utf8',
             // 数据库表前缀
             'prefix'   => 'test_',
+            // 是否需要断线重连
+            'break_reconnect' => false,
+            // 断线标识字符串
+            'break_match_str' => [],
+            // 数据库调试模式
+            'debug'    => false,
+        ],
+        'mysql_manage' => [
+            // 数据库类型
+            'type'     => 'mysql',
+            // 主机地址
+            'hostname' => getenv('TESTS_DB_MYSQL_HOSTNAME'),
+            // 数据库名
+            'database' => getenv('TESTS_DB_MYSQL_DATABASE'),
+            // 用户名
+            'username' => getenv('TESTS_DB_MYSQL_USERNAME'),
+            // 密码
+            'password' => getenv('TESTS_DB_MYSQL_PASSWORD'),
+            // 数据库编码默认采用utf8
+            'charset'  => 'utf8',
+            // 数据库表前缀
+            'prefix'   => 'test_',
             // 数据库调试模式
             'debug'    => false,
         ],

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -2,6 +2,8 @@
 
 namespace tests;
 
+use think\db\ConnectionInterface;
+use think\facade\Db;
 use function array_column;
 use function array_combine;
 use function array_map;
@@ -38,4 +40,15 @@ function array_value_sort(array $arr)
     foreach ($arr as &$value) {
         sort($value);
     }
+}
+
+function query_mysql_connection_id(ConnectionInterface $connect): int
+{
+    $cid = $connect->query('SELECT CONNECTION_ID() as cid')[0]['cid'];
+    return (int) $cid;
+}
+
+function mysql_kill_connection(string $name, $cid)
+{
+    Db::connect($name)->execute("KILL {$cid}");
 }

--- a/tests/orm/DbTest.php
+++ b/tests/orm/DbTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace tests\orm;
 
-use PHPUnit\Framework\TestCase;
+use tests\Base;
 use think\Collection;
 use think\db\Raw;
 use think\facade\Db;
@@ -14,7 +14,7 @@ use function array_values;
 use function tests\array_column_ex;
 use function tests\array_value_sort;
 
-class DbTest extends TestCase
+class DbTest extends Base
 {
     protected static $testUserData;
 

--- a/tests/orm/DbTransactionTest.php
+++ b/tests/orm/DbTransactionTest.php
@@ -1,0 +1,237 @@
+<?php
+declare(strict_types=1);
+
+namespace tests\orm;
+
+use PHPUnit\Framework\TestCase;
+use think\db\exception\DbException;
+use think\facade\Db;
+use function tests\mysql_kill_connection;
+use function tests\query_mysql_connection_id;
+
+class DbTransactionTest extends TestCase
+{
+    protected static $testData;
+
+    public static function setUpBeforeClass(): void
+    {
+        Db::execute('DROP TABLE IF EXISTS `test_tran_a`;');
+        Db::execute(<<<SQL
+CREATE TABLE `test_tran_a` (
+     `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+     `type` tinyint(4) NOT NULL DEFAULT '0',
+     `username` varchar(32) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SQL
+        );
+    }
+
+    public function setUp(): void
+    {
+        Db::execute('TRUNCATE TABLE `test_tran_a`;');
+        self::$testData = [
+            ['id' => 1, 'type' => 9, 'username' => '1-9-a'],
+            ['id' => 2, 'type' => 8, 'username' => '2-8-a'],
+            ['id' => 3, 'type' => 7, 'username' => '3-7-a'],
+        ];
+    }
+
+    public function testTransaction()
+    {
+        $testData = self::$testData;
+        $connect = Db::connect();
+
+        $connect->table('test_tran_a')->startTrans();
+        $connect->table('test_tran_a')->insertAll($testData);
+        $connect->table('test_tran_a')->rollback();
+
+        $this->assertEmpty($connect->table('test_tran_a')->column('*'));
+
+        $connect->execute('TRUNCATE TABLE `test_tran_a`;');
+        $connect->table('test_tran_a')->startTrans();
+        $connect->table('test_tran_a')->insertAll($testData);
+        $connect->table('test_tran_a')->commit();
+        $this->assertEquals($testData, $connect->table('test_tran_a')->column('*'));
+        $connect->table('test_tran_a')->startTrans();
+        $connect->table('test_tran_a')->where('id', '=', 2)->update([
+            'username' => '2-8-b',
+        ]);
+        $connect->table('test_tran_a')->commit();
+        $this->assertEquals(
+            '2-8-b',
+            $connect->table('test_tran_a')->where('id', '=', 2)->value('username')
+        );
+    }
+
+    public function testBreakReconnect()
+    {
+        $testData = self::$testData;
+        // 初始化配置
+        $config = Db::getConfig();
+        $config['connections']['mysql']['break_reconnect'] = true;
+        $config['connections']['mysql']['break_match_str'] = [
+            'query execution was interrupted',
+        ];
+        Db::setConfig($config);
+        // 初始化数据
+        $connect = Db::connect(null, true);
+        $connect->table('test_tran_a')->insertAll($testData);
+
+        $cid = query_mysql_connection_id($connect);
+        mysql_kill_connection('mysql_manage', $cid);
+        // 触发重连
+        $connect->table('test_tran_a')->where('id', '=', 2)->value('username');
+
+        $newCid = query_mysql_connection_id($connect);
+        $this->assertNotEquals($cid, $newCid);
+        $cid = $newCid;
+
+        // 事务前重连
+        mysql_kill_connection('mysql_manage', $cid);
+        Db::table('test_tran_a')->startTrans();
+        $connect->table('test_tran_a')->where('id', '=', 2)->update([
+            'username' => '2-8-b',
+        ]);
+        Db::table('test_tran_a')->commit();
+        $newCid = query_mysql_connection_id($connect);
+        $this->assertNotEquals($cid, $newCid);
+        $cid = $newCid;
+        $this->assertEquals(
+            '2-8-b',
+            Db::table('test_tran_a')->where('id', '=', 2)->value('username')
+        );
+
+        // 事务中不能重连
+        try {
+            Db::table('test_tran_a')->startTrans();
+            $connect->table('test_tran_a')->where('id', '=', 2)->update([
+                'username' => '2-8-c',
+            ]);
+            mysql_kill_connection('mysql_manage', $cid);
+            $connect->table('test_tran_a')->where('id', '=', 3)->update([
+                'username' => '3-7-b',
+            ]);
+            Db::table('test_tran_a')->commit();
+        } catch (DbException $exception) {
+            try {
+                Db::table('test_tran_a')->rollback();
+            } catch (\Exception $rollbackException) {
+                // Ignore exception
+                $this->assertMatchesRegularExpression(
+                    '~(server has gone away)~',
+                    $rollbackException->getMessage()
+                );
+            }
+            // Ignore exception
+            $this->assertMatchesRegularExpression(
+                '~(server has gone away)~',
+                $exception->getMessage()
+            );
+        }
+        // 预期应该没有发生任何更改
+        $this->assertEquals(
+            '2-8-b',
+            Db::table('test_tran_a')->where('id', '=', 2)->value('username')
+        );
+        $this->assertEquals(
+            '3-7-a',
+            Db::table('test_tran_a')->where('id', '=', 3)->value('username')
+        );
+    }
+
+    public function testTransactionSavepoint()
+    {
+        $testData = self::$testData;
+        // 初始化数据
+        $connect = Db::connect(null, true);
+        $connect->table('test_tran_a')->insertAll($testData);
+
+        Db::table('test_tran_a')->transaction(function () use ($connect) {
+            $cid = query_mysql_connection_id($connect);
+            // tran 1
+            Db::table('test_tran_a')->startTrans();
+            $connect->table('test_tran_a')->where('id', '=', 2)->update([
+                'username' => '2-8-c',
+            ]);
+            Db::table('test_tran_a')->commit();
+            // tran 2
+            Db::table('test_tran_a')->startTrans();
+            $connect->table('test_tran_a')->where('id', '=', 3)->update([
+                'username' => '3-7-b',
+            ]);
+            Db::table('test_tran_a')->commit();
+        });
+
+        // 预期变化
+        $this->assertEquals(
+            '2-8-c',
+            Db::table('test_tran_a')->where('id', '=', 2)->value('username')
+        );
+        $this->assertEquals(
+            '3-7-b',
+            Db::table('test_tran_a')->where('id', '=', 3)->value('username')
+        );
+    }
+
+    public function testTransactionSavepointBreakReconnect()
+    {
+        $testData = self::$testData;
+        // 初始化配置
+        $config = Db::getConfig();
+        $config['connections']['mysql']['break_reconnect'] = true;
+        $config['connections']['mysql']['break_match_str'] = [
+            'query execution was interrupted',
+        ];
+        Db::setConfig($config);
+        // 初始化数据
+        $connect = Db::connect(null, true);
+        $connect->table('test_tran_a')->insertAll($testData);
+
+        // 事务中不能重连
+        try {
+            // tran 0
+            Db::table('test_tran_a')->startTrans();
+            $cid = query_mysql_connection_id($connect);
+            // tran 1
+            Db::table('test_tran_a')->startTrans();
+            $connect->table('test_tran_a')->where('id', '=', 2)->update([
+                'username' => '2-8-c',
+            ]);
+            Db::table('test_tran_a')->commit();
+            // kill
+            mysql_kill_connection('mysql_manage', $cid);
+            // tran 2
+            Db::table('test_tran_a')->startTrans();
+            $connect->table('test_tran_a')->where('id', '=', 3)->update([
+                'username' => '3-7-b',
+            ]);
+            Db::table('test_tran_a')->commit();
+            // tran 0
+            Db::table('test_tran_a')->commit();
+        } catch (DbException | \PDOException $exception) {
+            try {
+                Db::table('test_tran_a')->rollback();
+            } catch (\Exception $rollbackException) {
+                // Ignore exception
+                $this->assertMatchesRegularExpression(
+                    '~(server has gone away)~',
+                    $rollbackException->getMessage()
+                );
+            }
+            // Ignore exception
+            $this->assertMatchesRegularExpression(
+                '~(server has gone away)~',
+                $exception->getMessage()
+            );
+        }
+        // 预期应该没有发生任何更改
+        $this->assertEquals(
+            '2-8-a',
+            Db::table('test_tran_a')->where('id', '=', 2)->value('username')
+        );
+        $this->assertEquals(
+            '3-7-a',
+            Db::table('test_tran_a')->where('id', '=', 3)->value('username')
+        );
+    }
+}

--- a/tests/orm/DbTransactionTest.php
+++ b/tests/orm/DbTransactionTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace tests\orm;
 
 use PHPUnit\Framework\TestCase;
-use think\db\exception\DbException;
 use think\facade\Db;
 use function tests\mysql_kill_connection;
 use function tests\query_mysql_connection_id;
@@ -112,7 +111,7 @@ SQL
                 'username' => '3-7-b',
             ]);
             Db::table('test_tran_a')->commit();
-        } catch (DbException $exception) {
+        } catch (\Throwable | \Exception $exception) {
             try {
                 Db::table('test_tran_a')->rollback();
             } catch (\Exception $rollbackException) {
@@ -208,7 +207,7 @@ SQL
             Db::table('test_tran_a')->commit();
             // tran 0
             Db::table('test_tran_a')->commit();
-        } catch (DbException | \PDOException $exception) {
+        } catch (\Throwable | \Exception $exception) {
             try {
                 Db::table('test_tran_a')->rollback();
             } catch (\Exception $rollbackException) {

--- a/tests/orm/DbTransactionTest.php
+++ b/tests/orm/DbTransactionTest.php
@@ -3,12 +3,14 @@ declare(strict_types=1);
 
 namespace tests\orm;
 
-use PHPUnit\Framework\TestCase;
+use Exception;
+use tests\Base;
 use think\facade\Db;
+use Throwable;
 use function tests\mysql_kill_connection;
 use function tests\query_mysql_connection_id;
 
-class DbTransactionTest extends TestCase
+class DbTransactionTest extends Base
 {
     protected static $testData;
 
@@ -111,18 +113,18 @@ SQL
                 'username' => '3-7-b',
             ]);
             Db::table('test_tran_a')->commit();
-        } catch (\Throwable | \Exception $exception) {
+        } catch (Throwable | Exception $exception) {
             try {
                 Db::table('test_tran_a')->rollback();
-            } catch (\Exception $rollbackException) {
+            } catch (Exception $rollbackException) {
                 // Ignore exception
-                $this->assertMatchesRegularExpression(
+                $this->proxyAssertMatchesRegularExpression(
                     '~(server has gone away)~',
                     $rollbackException->getMessage()
                 );
             }
             // Ignore exception
-            $this->assertMatchesRegularExpression(
+            $this->proxyAssertMatchesRegularExpression(
                 '~(server has gone away)~',
                 $exception->getMessage()
             );
@@ -207,18 +209,18 @@ SQL
             Db::table('test_tran_a')->commit();
             // tran 0
             Db::table('test_tran_a')->commit();
-        } catch (\Throwable | \Exception $exception) {
+        } catch (Throwable | Exception $exception) {
             try {
                 Db::table('test_tran_a')->rollback();
-            } catch (\Exception $rollbackException) {
+            } catch (Exception $rollbackException) {
                 // Ignore exception
-                $this->assertMatchesRegularExpression(
+                $this->proxyAssertMatchesRegularExpression(
                     '~(server has gone away)~',
                     $rollbackException->getMessage()
                 );
             }
             // Ignore exception
-            $this->assertMatchesRegularExpression(
+            $this->proxyAssertMatchesRegularExpression(
                 '~(server has gone away)~',
                 $exception->getMessage()
             );


### PR DESCRIPTION
1. 参考laravel的断连重试关键字进行补充 https://github.com/laravel/framework/blame/8.x/src/Illuminate/Database/DetectsLostConnections.php
2. ~缩小查询异常的捕获范围到`\PDOException `，仅处理可预知的异常（PHP7.4以下版本兼容有问题）~
3. 在事务中执行查询时不能进行断连重试，防止造成数据污染。
    - https://github.com/laravel/framework/blob/3c66f6cda2ac4ee2844a67fc98e676cb170ff4b1/src/Illuminate/Database/Connection.php#L725-L734
    - https://github.com/laravel/framework/issues/5937
4. 嵌套事务中不能对`startTrans`的`savepoint`进行断连重试，防止造成数据污染。
    - https://github.com/illuminate/database/blob/8904dfc7ae7b90ac8db5aae04bf8a1e8fcfc7abb/Concerns/ManagesTransactions.php#L131-L144

close #231 