### PR TITLE
优化列查询

### DIFF
--- a/src/db/PDOConnection.php
+++ b/src/db/PDOConnection.php
@@ -1244,7 +1244,13 @@ abstract class PDOConnection extends Connection
 
             $result = \array_column($resultSet, $column, $key);
         } elseif ($key) {
-            $result = \array_column($resultSet, null, $key);
+            $resultSet = \array_column($resultSet, null, $key);
+            if ('*' !== $column && \in_array($key, $field) && !\in_array($key, $column)) {
+                \array_walk($resultSet, function(&$item) use($key) {
+                    unset($item[$key]);
+                });
+            }
+            $result = $resultSet;
         } else {
             $result = $resultSet;
         }


### PR DESCRIPTION
多列查询时，索引字段会被自动加入返回数据，优化后会自动过滤掉索引字段（在需要索引字段时，可以写入需要字段）