### PR TITLE
修复paginate中 返回[] 而不是空数据集，而导致的hidden等方法无法调用

### DIFF
--- a/src/db/BaseQuery.php
+++ b/src/db/BaseQuery.php
@@ -621,7 +621,15 @@ abstract class BaseQuery
 
             $bind    = $this->bind;
             $total   = $this->count();
-            $results = $total > 0 ? $this->options($options)->bind($bind)->page($page, $listRows)->select() : [];
+            if ($total > 0) {
+                $results =  $this->options($options)->bind($bind)->page($page, $listRows)->select();
+            } else {
+                if (!empty($this->model)) {
+                    $results = new \think\model\Collection([]);
+                } else {
+                    $results = new \think\Collection([]);
+                }
+            }
         } elseif ($simple) {
             $results = $this->limit(($page - 1) * $listRows, $listRows + 1)->select();
             $total   = null;


### PR DESCRIPTION
如：class 'think\Collection' does not have a method 'hidden'