### PR TITLE
使withField的参数支持数组或字符串,使其表现与withoutField和文档一致.

### DIFF
--- a/src/model/Relation.php
+++ b/src/model/Relation.php
@@ -218,7 +218,7 @@ abstract class Relation
      * @param  array|string $field 关联字段限制
      * @return $this
      */
-    public function withField(array $field)
+    public function withField($field)
     {
         if (is_string($field)) {
             $field = array_map('trim', explode(',', $field));

--- a/src/model/Relation.php
+++ b/src/model/Relation.php
@@ -215,11 +215,15 @@ abstract class Relation
     /**
      * 限制关联数据的字段
      * @access public
-     * @param  array $field 关联字段限制
+     * @param  array|string $field 关联字段限制
      * @return $this
      */
     public function withField(array $field)
     {
+        if (is_string($field)) {
+            $field = array_map('trim', explode(',', $field));
+        }
+
         $this->withField = $field;
         return $this;
     }


### PR DESCRIPTION
withField方法仅支持数组格式,但是文档中有字符串的使用案例,并且withoutField方法也是支持数组和字符串的.