### PR TITLE
在更新或删除时模型实例存在时则插入主键限制条件

### DIFF
--- a/src/db/BaseQuery.php
+++ b/src/db/BaseQuery.php
@@ -1055,7 +1055,7 @@ abstract class BaseQuery
             $this->parseUpdateData($this->options['data']);
         }
 
-        if (empty($this->options['where']) && $this->model) {
+        if ($this->model) {
             $this->where($this->model->getWhere());
         }
 
@@ -1081,7 +1081,7 @@ abstract class BaseQuery
             $this->parsePkWhere($data);
         }
 
-        if (empty($this->options['where']) && $this->model) {
+        if ($this->model) {
             $this->where($this->model->getWhere());
         }
 


### PR DESCRIPTION
老版有个问题，如果有全局查询范围或是添加了额外的条件，则会丢失主键条件
如:
```
$model = Model::find(1);
$model->inc('field', 2)->where([ 'other' => 'value' ])->update();
```
这个更新的SQL会变成 `update model set field = field + 2 where other = value`，如果有个全局查询范围也会导致这样的情况，这样的行为结果有点反直觉反人类。

我不知道这样改下有没有其它影响，可以当作一个改进提议。