### PR TITLE
修复Model直接实例化传参不能保存有类型转换的字段

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -217,15 +217,15 @@ abstract class Model implements JsonSerializable, ArrayAccess, Arrayable, Jsonab
      */
     public function __construct(array $data = [])
     {
-        $this->data = $data;
-
-        if (!empty($this->data)) {
+        if (!empty($data)) {
             // 废弃字段
             foreach ((array) $this->disuse as $key) {
-                if (array_key_exists($key, $this->data)) {
-                    unset($this->data[$key]);
+                if (array_key_exists($key, $data)) {
+                    unset($data[$key]);
                 }
             }
+            
+            $this->setAttrs($data);
         }
 
         // 记录原始数据


### PR DESCRIPTION
修改前：
```php
$model = new Model([
   'name' => 'some',
   'type' => $type, // 是个对象，定义了类型转换
]);
$model->save(); // type 不见了，查看 SQL 也没有，数据库当然也没有
```

修改后：
```php
$model = new Model([
   'name' => 'some',
   'type' => $type, // 是个对象，定义了类型转换
]);
$model->save(); // type 被转换为正常的值并成功保存到数据库
```