### PR TITLE
修复count和group同时使用时,count的sql注入问题

### DIFF
--- a/src/db/concern/AggregateQuery.php
+++ b/src/db/concern/AggregateQuery.php
@@ -12,6 +12,7 @@ declare (strict_types = 1);
 
 namespace think\db\concern;
 
+use think\db\exception\DbException;
 use think\db\Raw;
 
 /**
@@ -42,6 +43,11 @@ trait AggregateQuery
     {
         if (!empty($this->options['group'])) {
             // 支持GROUP
+
+            if (!preg_match('/^[\w\.\*]+$/', $field)) {
+                throw new DbException('not support data:' . $field);
+            }
+
             $options = $this->getOptions();
             $subSql  = $this->options($options)
                 ->field('count(' . $field . ') AS think_count')

--- a/src/model/Relation.php
+++ b/src/model/Relation.php
@@ -218,7 +218,7 @@ abstract class Relation
      * @param  array|string $field 关联字段限制
      * @return $this
      */
-    public function withField(array $field)
+    public function withField($field)
     {
         if (is_string($field)) {
             $field = array_map('trim', explode(',', $field));

--- a/src/model/Relation.php
+++ b/src/model/Relation.php
@@ -215,11 +215,15 @@ abstract class Relation
     /**
      * 限制关联数据的字段
      * @access public
-     * @param  array $field 关联字段限制
+     * @param  array|string $field 关联字段限制
      * @return $this
      */
     public function withField(array $field)
     {
+        if (is_string($field)) {
+            $field = array_map('trim', explode(',', $field));
+        }
+
         $this->withField = $field;
         return $this;
     }


### PR DESCRIPTION
用法如下时:
```
        $title = FacadeRequest::get('title');
        $field = FacadeRequest::get('field');       // id  AND (SELECT 1555 FROM (SELECT(SLEEP(4)))Tfbh)

        $fqModel = new MallGoods();
        $result = $fqModel->where(['title' => $title])
        ->group('cate_id')
        ->count($field);
```
传入的filed会被注入:
```
public function count(string $field = '*'): int
    {
        if (!empty($this->options['group'])) {
            // 支持GROUP

            if (!preg_match('/^[\w\.\*]+$/', $field)) {
                throw new DbException('not support data:' . $field);
            }

            $options = $this->getOptions();
            $subSql  = $this->options($options)
                ->field('count(' . $field . ') AS think_count')
                ->bind($this->bind)
                ->buildSql();

            $query = $this->newQuery()->table([$subSql => '_group_count_']);

            $count = $query->aggregate('COUNT', '*');
        } else {
            $count = $this->aggregate('COUNT', $field);
        }

        return (int) $count;
    }
```

其他聚合方法传入的数据最终都会被`builder`的`parseKey`方法检查,但是count与group一同使用时,使用的子查询并没有验证字段.
```
AggregateQuery:
    public function sum($field): float
    {
        return $this->aggregate('SUM', $field, true);
    }
    protected function aggregate(string $aggregate, $field, bool $force = false)
    {
        return $this->connection->aggregate($this, $aggregate, $field, $force);
    }
....
PDO:
    public function aggregate(BaseQuery $query, string $aggregate, $field, bool $force = false)
    {
        if (is_string($field) && 0 === stripos($field, 'DISTINCT ')) {
            [$distinct, $field] = explode(' ', $field);
        }

        $field = $aggregate . '(' . (!empty($distinct) ? 'DISTINCT ' : '') . $this->builder->parseKey($query, $field, true) . ') AS think_' . strtolower($aggregate);

        $result = $this->value($query, $field, 0);

        return $force ? (float) $result : $result;
    }
```