### PR TITLE
增加客户端是否信任服务器自建证书连接选项

### DIFF
--- a/src/db/connector/Sqlsrv.php
+++ b/src/db/connector/Sqlsrv.php
@@ -44,6 +44,10 @@ class Sqlsrv extends PDOConnection
             $dsn .= ',' . $config['hostport'];
         }
 
+        if (!empty($config['trust_server_certificate'])) {
+            $dsn .= ';TrustServerCertificate=' . $config['trust_server_certificate'];
+        }
+
         return $dsn;
     }
 


### PR DESCRIPTION
当升级为ODBC Driver 18 for SQL Server，可能会导致链接错误
`SQLSTATE[08001]: [Microsoft][ODBC Driver 18 for SQL Server]SSL Provider: [error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:self signed certificate]`