### PR TITLE
修正查询问题

### DIFF
--- a/src/db/connector/Oracle.php
+++ b/src/db/connector/Oracle.php
@@ -51,7 +51,7 @@ class Oracle extends PDOConnection
     public function getFields(string $tableName): array
     {
         [$tableName] = explode(' ', $tableName);
-        $sql         = "select a.column_name,data_type,DECODE (nullable, 'Y', 0, 1) notnull,data_default, DECODE (A .column_name,b.column_name,1,0) pk from all_tab_columns a,(select column_name from all_constraints c, all_cons_columns col where c.constraint_name = col.constraint_name and c.constraint_type = 'P' and c.table_name = '" . strtoupper($tableName) . "' ) b where table_name = '" . strtoupper($tableName) . "' and a.column_name = b.column_name (+)";
+        $sql         = "select a.column_name,data_type,DECODE (nullable, 'Y', 0, 1) notnull,data_default, DECODE (A .column_name,b.column_name,1,0) pk from all_tab_columns a,(select column_name from all_constraints c, all_cons_columns col where c.constraint_name = col.constraint_name and c.constraint_type = 'P' and c.table_name = '" . $tableName . "' ) b where table_name = '" . $tableName . "' and a.column_name = b.column_name (+)";
 
         $pdo    = $this->getPDOStatement($sql);
         $result = $pdo->fetchAll(PDO::FETCH_ASSOC);
@@ -98,16 +98,18 @@ class Oracle extends PDOConnection
     /**
      * 获取最近插入的ID
      * @access public
-     * @param BaseQuery $query    查询对象
-     * @param string    $sequence 自增序列名
+     * @param BaseQuery $query 查询对象
+     * @param string|null $sequence 自增序列名
      * @return mixed
      */
     public function getLastInsID(BaseQuery $query, string $sequence = null)
     {
-        $pdo    = $this->linkID->query("select {$sequence}.currval as id from dual");
-        $result = $pdo->fetchColumn();
+        if(is_null($sequence)) {
+            $pdo    = $this->linkID->query("select {$sequence}.currval as id from dual");
+            $result = $pdo->fetchColumn();
+        }
 
-        return $result;
+        return $result ?? null;
     }
 
     protected function supportSavepoint(): bool

--- a/src/db/connector/Oracle.php
+++ b/src/db/connector/Oracle.php
@@ -104,7 +104,7 @@ class Oracle extends PDOConnection
      */
     public function getLastInsID(BaseQuery $query, string $sequence = null)
     {
-        if(is_null($sequence)) {
+        if(!is_null($sequence)) {
             $pdo    = $this->linkID->query("select {$sequence}.currval as id from dual");
             $result = $pdo->fetchColumn();
         }


### PR DESCRIPTION
1.Oracle表名与字段加双引号则区分大小，目前数据库设计工具都默认加上了双引号，所以使用原本的查询方法，可能发生找不到表的错误
2.修正没有传入自增列插入数据报错的问题