### PR TITLE
修复时间字段为 0 时，获取到的值为 null 的问题

### DIFF
--- a/src/model/concern/TimeStamp.php
+++ b/src/model/concern/TimeStamp.php
@@ -179,7 +179,7 @@ trait TimeStamp
     protected function formatDateTime($format, $time = 'now', bool $timestamp = false)
     {
         if (empty($time)) {
-            return;
+            return $time;
         }
 
         if (false === $format) {


### PR DESCRIPTION
create_time 字段保存的是时间戳，当 create_time = 0 时，同时也不想转 datetime 格式，这个时候需要直接拿到 int 类型的数据，而不是 null 类型