### PR TITLE
TimeStamp.php 解决当表没有create_time和update_time字段时无法执行软删的问题；

### DIFF
--- a/src/db/BaseQuery.php
+++ b/src/db/BaseQuery.php
@@ -1095,7 +1095,8 @@ abstract class BaseQuery
             list($field, $condition) = $this->options['soft_delete'];
             if ($condition) {
                 unset($this->options['soft_delete']);
-                $this->options['data'] = [$field => $condition];
+                $deleteTime = $this->model->autoWriteTimestamp(str_replace('__TABLE__.', '', $field));
+                $this->options['data'] = [$field => $deleteTime];
 
                 return $this->connection->update($this);
             }

--- a/src/model/concern/TimeStamp.php
+++ b/src/model/concern/TimeStamp.php
@@ -72,6 +72,8 @@ trait TimeStamp
             } else {
                 $type = $this->getFieldType($this->createTime);
             }
+        } elseif ( is_string($type) ) {
+            $type = $this->getFieldType($type);
         }
 
         return $type;
@@ -130,10 +132,10 @@ trait TimeStamp
      * @access protected
      * @return mixed
      */
-    protected function autoWriteTimestamp()
+    public function autoWriteTimestamp($column = true)
     {
         // 检测时间字段类型
-        $type = $this->checkTimeFieldType($this->autoWriteTimestamp);
+        $type = $this->checkTimeFieldType($column ?: $this->autoWriteTimestamp);
 
         return is_string($type) ? $this->getTimeTypeValue($type) : time();
     }


### PR DESCRIPTION
TimeStamp.php 解决当表没有create_time和update_time字段只有delete_time时无法执行软删的问题；
BaseQuery.php 使DB查询也能使用软删除：
```
$user = new User;
$user->where('id',1)->delete(); // 软删除
```