### PR TITLE
一对一关联预查寻支持其他关联表字段作为外键

### DIFF
--- a/src/model/relation/OneToOne.php
+++ b/src/model/relation/OneToOne.php
@@ -91,9 +91,23 @@ abstract class OneToOne extends Relation
         $query->via($joinAlias);
 
         if ($this instanceof BelongsTo) {
-            $joinOn = $name . '.' . $this->foreignKey . '=' . $joinAlias . '.' . $this->localKey;
+
+            $foreignKeyExp = $this->foreignKey;
+
+            if (strpos($foreignKeyExp, '.') === false) {
+                $foreignKeyExp = $name . '.' . $this->foreignKey;
+            }
+
+            $joinOn = $foreignKeyExp . '=' . $joinAlias . '.' . $this->localKey;
         } else {
-            $joinOn = $name . '.' . $this->localKey . '=' . $joinAlias . '.' . $this->foreignKey;
+            
+            $foreignKeyExp = $this->foreignKey;
+
+            if (strpos($foreignKeyExp, '.') === false) {
+                $foreignKeyExp = $joinAlias . '.' . $this->foreignKey;
+            }
+
+            $joinOn = $name . '.' . $this->localKey . '=' . $foreignKeyExp;
         }
 
         if ($closure) {


### PR DESCRIPTION
### 介绍

模型定义一对一关联时，关联外键可以定义为其他关联表字段。

比如一个模型的关联定义如下：
```
    public function appPersion()
    {
        return $this->belongsTo(AppPersionInfo::class, 'persion_id');
    }

    public function appCommunity()
    {
        return $this->belongsTo(AppCommunity::class, 'appPersion.community_id');
    }

    public function appTown()
    {
        return $this->belongsTo(AppTown::class, 'appCommunity.town_id');
    }
```
显然，`appPersion.community_id`并不是当前模型表的字段，而是关联的`appPersion`表中的一个字段。但仍然可以做关联查询。

```
->withJoin(['appPersion', 'appCommunity', 'appTown'], 'LEFT')
```

在之前，只能通过当前模型表的字段做关联查询。

### 可能产生的影响

不会对原有的任何功能产生影响。

### 实现难度

这是一个很简单的实现，只需要判断传入的外键是否含有点`.`即可。