### PR TITLE
修复关联更新检测关联模型字段bug

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -625,7 +625,7 @@ abstract class Model implements JsonSerializable, ArrayAccess, Arrayable, Jsonab
                 continue;
             }
 
-            foreach ($val as $key) {
+            foreach (array_keys($val) as $key) {
                 if (isset($data[$key])) {
                     unset($data[$key]);
                 }


### PR DESCRIPTION
[1] 报错信息 ：Illegal offset type in isset or empty
[2] 报错原因：置了exp 属性: 比如 $info->setAttrs(["abc"=>Db::raw("score+1")])：
[3] 报错地址: \vendor\topthink\think-orm\src\Model.php 625 行：
~~~
foreach ($this->relationWrite as $name => $val) {
    if (!is_array($val)) {
        continue;
    }
    foreach ($val as $key) {  // 应该改为  foreach (array_keys($val) as $key) 
        if (isset($data[$key])) {
            unset($data[$key]);
        }
    }
}
~~~