### PR TITLE
增强关系模型定义

### DIFF
--- a/src/model/concern/RelationShip.php
+++ b/src/model/concern/RelationShip.php
@@ -627,9 +627,12 @@ trait RelationShip
      * @param  string       $middle 中间表名/模型名
      * @param  string|array $morph 多态字段信息
      * @param  string       $localKey   当前模型关联键
+     * @param  string       $modelKey 关联模型关联键
+     * @param  string       $parentKey 上级模型关联键
      * @return MorphToMany
      */
-    public function morphToMany(string $model, string $middle, $morph = null, string $localKey = null): MorphToMany
+    public function morphToMany(string $model, string $middle, $morph = null, string $localKey = null,
+                                string $modelKey = '', string $parentKey = ''): MorphToMany
     {
         if (is_null($morph)) {
             $morph = $middle;
@@ -647,7 +650,7 @@ trait RelationShip
         $name     = Str::snake(class_basename($model));
         $localKey = $localKey ?: $this->getForeignKey($name);
 
-        return new MorphToMany($this, $model, $middle, $morphType, $morphKey, $localKey);
+        return new MorphToMany($this, $model, $middle, $morphType, $morphKey, $localKey, false, $modelKey, $parentKey);
     }
 
     /**
@@ -657,9 +660,12 @@ trait RelationShip
      * @param  string       $middle 中间表名/模型名
      * @param  string|array $morph 多态字段信息
      * @param  string       $foreignKey 关联外键
+     * @param  string       $modelKey 关联模型关联键
+     * @param  string       $parentKey 上级模型关联键
      * @return MorphToMany
      */
-    public function morphByMany(string $model, string $middle, $morph = null, string $foreignKey = null): MorphToMany
+    public function morphByMany(string $model, string $middle, $morph = null, string $foreignKey = null,
+                                string $modelKey = '', string $parentKey = ''): MorphToMany
     {
         if (is_null($morph)) {
             $morph = $middle;
@@ -676,7 +682,7 @@ trait RelationShip
         $model      = $this->parseModel($model);
         $foreignKey = $foreignKey ?: $this->getForeignKey($this->name);
 
-        return new MorphToMany($this, $model, $middle, $morphType, $morphKey, $foreignKey, true);
+        return new MorphToMany($this, $model, $middle, $morphType, $morphKey, $foreignKey, true, $modelKey, $parentKey);
     }
 
     /**

--- a/src/model/concern/RelationShip.php
+++ b/src/model/concern/RelationShip.php
@@ -514,11 +514,14 @@ trait RelationShip
      * @access public
      * @param  string $model      模型名
      * @param  string $middle     中间表/模型名
-     * @param  string $foreignKey 关联外键
-     * @param  string $localKey   当前模型关联键
+     * @param  string $foreignKey 中间表中关联外键
+     * @param  string $localKey   中间表中当前模型关联键
+     * @param  string $modelKey   关联模型关联键
+     * @param  string $parentKey  上级模型关联键
      * @return BelongsToMany
      */
-    public function belongsToMany(string $model, string $middle = '', string $foreignKey = '', string $localKey = ''): BelongsToMany
+    public function belongsToMany(string $model, string $middle = '', string $foreignKey = '', string $localKey = '',
+                                  string $modelKey = '', string $parentKey = ''): BelongsToMany
     {
         // 记录当前关联信息
         $model      = $this->parseModel($model);
@@ -527,7 +530,7 @@ trait RelationShip
         $foreignKey = $foreignKey ?: $name . '_id';
         $localKey   = $localKey ?: $this->getForeignKey($this->name);
 
-        return new BelongsToMany($this, $model, $middle, $foreignKey, $localKey);
+        return new BelongsToMany($this, $model, $middle, $foreignKey, $localKey, $modelKey, $parentKey);
     }
 
     /**

--- a/src/model/concern/RelationShip.php
+++ b/src/model/concern/RelationShip.php
@@ -536,12 +536,13 @@ trait RelationShip
     /**
      * MORPH  One 关联定义
      * @access public
-     * @param  string       $model 模型名
-     * @param  string|array $morph 多态字段信息
-     * @param  string       $type  多态类型
+     * @param  string       $model     模型名
+     * @param  string|array $morph     多态字段信息
+     * @param  string       $type      多态类型
+     * @param  string       $parentKey 上级模型关联键
      * @return MorphOne
      */
-    public function morphOne(string $model, $morph = null, string $type = ''): MorphOne
+    public function morphOne(string $model, $morph = null, string $type = '', string $parentKey = ''): MorphOne
     {
         // 记录当前关联信息
         $model = $this->parseModel($model);
@@ -560,18 +561,19 @@ trait RelationShip
 
         $type = $type ?: get_class($this);
 
-        return new MorphOne($this, $model, $foreignKey, $morphType, $type);
+        return new MorphOne($this, $model, $foreignKey, $morphType, $type, $parentKey);
     }
 
     /**
      * MORPH  MANY 关联定义
      * @access public
-     * @param  string       $model 模型名
-     * @param  string|array $morph 多态字段信息
-     * @param  string       $type  多态类型
+     * @param  string       $model     模型名
+     * @param  string|array $morph     多态字段信息
+     * @param  string       $type      多态类型
+     * @param  string       $parentKey 上级模型关联键
      * @return MorphMany
      */
-    public function morphMany(string $model, $morph = null, string $type = ''): MorphMany
+    public function morphMany(string $model, $morph = null, string $type = '', string $parentKey = ''): MorphMany
     {
         // 记录当前关联信息
         $model = $this->parseModel($model);
@@ -590,17 +592,18 @@ trait RelationShip
             $foreignKey = $morph . '_id';
         }
 
-        return new MorphMany($this, $model, $foreignKey, $morphType, $type);
+        return new MorphMany($this, $model, $foreignKey, $morphType, $type, $parentKey);
     }
 
     /**
      * MORPH TO 关联定义
      * @access public
-     * @param  string|array $morph 多态字段信息
-     * @param  array        $alias 多态别名定义
+     * @param  string|array $morph     多态字段信息
+     * @param  array        $alias     多态别名定义
+     * @param  ?string      $parentKey 上级模型关联键
      * @return MorphTo
      */
-    public function morphTo($morph = null, array $alias = []): MorphTo
+    public function morphTo($morph = null, array $alias = [], string $parentKey = ''): MorphTo
     {
         $trace    = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
         $relation = Str::snake($trace[1]['function']);
@@ -617,7 +620,7 @@ trait RelationShip
             $foreignKey = $morph . '_id';
         }
 
-        return new MorphTo($this, $morphType, $foreignKey, $alias, $relation);
+        return new MorphTo($this, $morphType, $foreignKey, $alias, $relation, $parentKey);
     }
 
     /**

--- a/src/model/relation/MorphOne.php
+++ b/src/model/relation/MorphOne.php
@@ -42,6 +42,12 @@ class MorphOne extends Relation
     protected $type;
 
     /**
+     * 上级模型关联键
+     * @var string
+     */
+    protected $parentKey;
+
+    /**
      * 绑定的关联属性
      * @var array
      */
@@ -55,14 +61,17 @@ class MorphOne extends Relation
      * @param  string $morphKey  关联外键
      * @param  string $morphType 多态字段名
      * @param  string $type      多态类型
+     * @param  string $parentKey 上级模型关联键
      */
-    public function __construct(Model $parent, string $model, string $morphKey, string $morphType, string $type)
+    public function __construct(Model $parent, string $model, string $morphKey, string $morphType, string $type,
+                                string $parentKey = '')
     {
         $this->parent    = $parent;
         $this->model     = $model;
         $this->type      = $type;
         $this->morphKey  = $morphKey;
         $this->morphType = $morphType;
+        $this->parentKey  = $parentKey ?: $parent->getPk();
         $this->query     = (new $model)->db();
     }
 
@@ -276,7 +285,7 @@ class MorphOne extends Relation
         }
 
         // 保存关联表数据
-        $pk = $this->parent->getPk();
+        $pk = $this->parentKey;
 
         $data[$this->morphKey]  = $this->parent->$pk;
         $data[$this->morphType] = $this->type;
@@ -292,7 +301,7 @@ class MorphOne extends Relation
     protected function baseQuery(): void
     {
         if (empty($this->baseQuery) && $this->parent->getData()) {
-            $pk = $this->parent->getPk();
+            $pk = $this->parentKey;
 
             $this->query->where([
                 [$this->morphKey, '=', $this->parent->$pk],

--- a/tests/orm/ModelBelongsToManyRelationshipTest.php
+++ b/tests/orm/ModelBelongsToManyRelationshipTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace tests\orm;
+
+use tests\Base;
+use think\facade\Db;
+use think\Model;
+
+class ModelBelongsToManyRelationshipTest extends Base
+{
+    public static function setUpBeforeClass(): void
+    {
+        Db::execute('DROP TABLE IF EXISTS `test_user`;');
+        Db::execute(<<<SQL
+CREATE TABLE `test_user` (
+     `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+     `name` varchar(32) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SQL
+        );
+        Db::execute('DROP TABLE IF EXISTS `test_role`;');
+        Db::execute(<<<SQL
+CREATE TABLE `test_role` (
+     `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+     `name` varchar(32) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SQL
+        );
+        Db::execute('DROP TABLE IF EXISTS `test_user_role`;');
+        Db::execute(<<<SQL
+CREATE TABLE `test_user_role` (
+     `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+     `user_id` int(10) NOT NULL,
+     `role_id` int(10) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SQL
+        );
+    }
+
+    public function setUp(): void
+    {
+        Db::execute('TRUNCATE TABLE `test_user`');
+        Db::execute('TRUNCATE TABLE `test_role`');
+        Db::execute('TRUNCATE TABLE `test_user_role`');
+        Db::table('test_user')->insertAll([
+            ['id' => 1, 'name' => 'user1'],
+        ]);
+        Db::table('test_role')->insertAll([
+            ['id' => 1, 'name' => 'role1'],
+        ]);
+    }
+
+    public function testAttachDetachRelations()
+    {
+        $user = BelongsToManyUser::find(1);
+        $this->assertEquals(0, $user->roles()->count());
+        $user->roles()->attach(1);
+        $this->assertEquals(['role1'], $user->roles()->column('name'));
+        $user->roles()->detach(1);
+        $this->assertEquals(0, $user->roles()->count());
+    }
+}
+
+class BelongsToManyUser extends Model
+{
+    protected $table = 'test_user';
+
+    public function roles()
+    {
+        return $this->belongsToMany(BelongsToManyRole::class, 'user_role', 'role_id', 'user_id', 'id', 'id');
+    }
+}
+
+class BelongsToManyRole extends Model
+{
+    protected $table = 'test_role';
+}

--- a/tests/orm/ModelMorphManyRelationshipTest.php
+++ b/tests/orm/ModelMorphManyRelationshipTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace tests\orm;
+
+use tests\Base;
+use think\facade\Db;
+use think\Model;
+
+class ModelMorphManyRelationshipTest extends Base
+{
+    public static function setUpBeforeClass(): void
+    {
+        Db::execute('DROP TABLE IF EXISTS `test_article`;');
+        Db::execute(<<<SQL
+CREATE TABLE `test_article` (
+     `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+     `title` varchar(32) NOT NULL,
+     `content` text NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SQL
+        );
+        Db::execute('DROP TABLE IF EXISTS `test_comment`;');
+        Db::execute(<<<SQL
+CREATE TABLE `test_comment` (
+     `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+     `content` text NOT NULL,
+     `commentable_id` int(10) NOT NULL,
+     `commentable_type` varchar(128) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SQL
+        );
+    }
+
+    public function setUp(): void
+    {
+        Db::execute('TRUNCATE TABLE `test_article`');
+        Db::execute('TRUNCATE TABLE `test_comment`');
+        Db::table('test_article')->insertAll([
+            ['id' => 1, 'title' => 'a title', 'content' => 'a content'],
+        ]);
+        Db::table('test_comment')->insertAll([
+            ['id' => 1, 'content' => 'a comment', 'commentable_id' => 1, 'commentable_type' => MorphManyArticle::class],
+        ]);
+    }
+
+    public function testAttachDetachRelations()
+    {
+        $a = MorphManyArticle::find(1);
+        $this->assertContains('a comment', $a->comments->column('content'));
+        $comment = MorphManyComment::find(1);
+        $this->assertEquals($a->id, $comment->commentable->id);
+    }
+}
+
+class MorphManyArticle extends Model
+{
+    protected $table = 'test_article';
+
+    public function comments()
+    {
+        return $this->morphMany(MorphManyComment::class, 'commentable');
+    }
+}
+
+class MorphManyComment extends Model
+{
+    protected $table = 'test_comment';
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
+}

--- a/tests/orm/ModelMorphOneRelationshipTest.php
+++ b/tests/orm/ModelMorphOneRelationshipTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace tests\orm;
+
+use tests\Base;
+use think\facade\Db;
+use think\Model;
+
+class ModelMorphOneRelationshipTest extends Base
+{
+    public static function setUpBeforeClass(): void
+    {
+        Db::execute('DROP TABLE IF EXISTS `test_member`;');
+        Db::execute(<<<SQL
+CREATE TABLE `test_member` (
+     `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+     `name` varchar(32) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SQL
+        );
+        Db::execute('DROP TABLE IF EXISTS `test_avatar`;');
+        Db::execute(<<<SQL
+CREATE TABLE `test_avatar` (
+     `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+     `avatar` varchar(128) NOT NULL,
+     `imageable_id` int(10) NOT NULL,
+     `imageable_type` varchar(128) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SQL
+        );
+    }
+
+    public function setUp(): void
+    {
+        Db::execute('TRUNCATE TABLE `test_member`');
+        Db::execute('TRUNCATE TABLE `test_avatar`');
+        Db::table('test_member')->insertAll([
+            ['id' => 1, 'name' => 'member1'],
+        ]);
+        Db::table('test_avatar')->insertAll([
+            ['id' => 1, 'avatar' => 'http://example.com/avatar.jpg', 'imageable_id' => 1, 'imageable_type' => MorphOneMember::class],
+        ]);
+    }
+
+    public function testAttachDetachRelations()
+    {
+        $m = MorphOneMember::find(1);
+        $this->assertEquals('http://example.com/avatar.jpg', $m->avatar->avatar);
+        $avatar = MorphOneAvatar::find(1);
+        $this->assertEquals($m->id, $avatar->imageable->id);
+    }
+}
+
+class MorphOneMember extends Model
+{
+    protected $table = 'test_member';
+
+    public function avatar()
+    {
+        return $this->morphOne(MorphOneAvatar::class, 'imageable');
+    }
+}
+
+class MorphOneAvatar extends Model
+{
+    protected $table = 'test_avatar';
+
+    public function imageable()
+    {
+        return $this->morphTo();
+    }
+}

--- a/tests/orm/ModelMorphToManyRelationshipTest.php
+++ b/tests/orm/ModelMorphToManyRelationshipTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace tests\orm;
+
+use tests\Base;
+use think\facade\Db;
+use think\Model;
+
+class ModelMorphToManyRelationshipTest extends Base
+{
+    public static function setUpBeforeClass(): void
+    {
+        Db::execute('DROP TABLE IF EXISTS `test_user`;');
+        Db::execute(<<<SQL
+CREATE TABLE `test_user` (
+     `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+     `name` varchar(32) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SQL
+        );
+        Db::execute('DROP TABLE IF EXISTS `test_role`;');
+        Db::execute(<<<SQL
+CREATE TABLE `test_role` (
+     `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+     `name` varchar(32) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SQL
+        );
+        Db::execute('DROP TABLE IF EXISTS `test_accessible_role`;');
+        Db::execute(<<<SQL
+CREATE TABLE `test_accessible_role` (
+     `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+     `accessible_id` int(10) NOT NULL,
+     `accessible_type` varchar(128) NOT NULL,
+     `role_id` int(10) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SQL
+        );
+    }
+
+    public function setUp(): void
+    {
+        Db::execute('TRUNCATE TABLE `test_user`');
+        Db::execute('TRUNCATE TABLE `test_role`');
+        Db::execute('TRUNCATE TABLE `test_accessible_role`');
+        Db::table('test_user')->insertAll([
+            ['id' => 1, 'name' => 'user1'],
+        ]);
+        Db::table('test_role')->insertAll([
+            ['id' => 1, 'name' => 'role1'],
+        ]);
+    }
+
+    public function testAttachDetachRelations()
+    {
+        $user = MorphToManyUser::find(1);
+        $this->assertEquals(0, $user->roles()->count());
+        $user->roles()->attach(1);
+        $this->assertEquals(['role1'], $user->roles()->column('name'));
+        $role = MorphToManyRole::find(1);
+        $user->roles()->detach($role);
+        $this->assertEquals(0, $user->roles()->count());
+        $role->accessable()->attach($user);
+        $this->assertContains($user->id, $role->accessable->column('id'));
+    }
+}
+
+class MorphToManyUser extends Model
+{
+    protected $table = 'test_user';
+
+    public function roles()
+    {
+        return $this->morphToMany(MorphToManyRole::class, 'accessible_role', 'accessible', 'role_id', 'id', 'id');
+    }
+}
+
+class MorphToManyRole extends Model
+{
+    protected $table = 'test_role';
+
+    public function accessable()
+    {
+        return $this->morphByMany(MorphToManyUser::class, 'accessible_role', 'accessible', 'role_id', 'id', 'id');
+    }
+}


### PR DESCRIPTION
- `BelongsToMany`, `MorphToMany` 增加自定义上级模型关联键和当前模型的关联键
- `MorphOne`, `MorphMany`以及`MorphTo` 增加自定义上级模型关联键
- 修复 `MorphTo` new 的语法错误

这个自定义的关联键可以很方便使用非主键进行关联关系模型，例如`User`模型可以通过`account_id`与`Role`模型进行多对多的关联，同时兼容之前的版本。

```php
<?php
class User {
    ...
    public function roles()
    {
        $this->belongsToMany(Role::class, 'user_role', 'role_id', 'user_id', 'id', 'account_id');
    }
}