### PR TITLE
修正 column() 获取 json 字段无结果

### DIFF
--- a/src/db/PDOConnection.php
+++ b/src/db/PDOConnection.php
@@ -1246,6 +1246,8 @@ abstract class PDOConnection extends Connection
                 [$alias, $column] = \explode('.', $column);
             }
 
+            $column = $this->builder->parseKey($query, $column);
+
             $result = \array_column($resultSet, $column, $key);
         } elseif ($key) {
             $result = \array_column($resultSet, null, $key);

--- a/src/db/PDOConnection.php
+++ b/src/db/PDOConnection.php
@@ -1246,7 +1246,7 @@ abstract class PDOConnection extends Connection
                 [$alias, $column] = \explode('.', $column);
             }
 
-            $column = $this->builder->parseKey($query, $column);
+            $column = trim($this->builder->parseKey($query, $column), '`');
 
             $result = \array_column($resultSet, $column, $key);
         } elseif ($key) {


### PR DESCRIPTION
使用JSON字段查询时，`search->short`自动转换为了`json_extract(`search`, '$.short')`，因此`$this->builder->select($query)`查询出来的结果集是
```
array:7 [
  0 => array:1 [
    "json_extract(`search`, '$.short')" => ""中石化""
  ]
  1 => array:1 [
    "json_extract(`search`, '$.short')" => null
  ]
  2 => array:1 [
    "json_extract(`search`, '$.short')" => """"
  ]
  3 => array:1 [
    "json_extract(`search`, '$.short')" => ""待定""
  ]
  4 => array:1 [
    "json_extract(`search`, '$.short')" => ""新车队""
  ]
  5 => array:1 [
    "json_extract(`search`, '$.short')" => ""102""
  ]
  6 => array:1 [
    "json_extract(`search`, '$.short')" => ""一客一议""
  ]
]
```
但`column()`处理结果集时，用的还是`search->short`，导致`array_column($resultSet, $column, $key)`获取不到数据。

### 用法
```php
\think\facade\Db::table('base_rule')->json(['search'])->distinct()->where('fleet_id', app('user')->current_fleet)->column('search->short');
```