### PR TITLE
访问模型的多层关联模型的bug

### DIFF
--- a/src/model/concern/RelationShip.php
+++ b/src/model/concern/RelationShip.php
@@ -760,6 +760,7 @@ trait RelationShip
         if (
             $this->parent && !$modelRelation->isSelfRelation()
             && get_class($this->parent) == get_class($modelRelation->getModel())
+            && $modelRelation instanceof OneToOne
         ) {
             return $this->parent;
         }


### PR DESCRIPTION
RelationShip模型关联处理类->getRelationData智能获取关联模型数据方法
增加判断条件：属于（继承于）一对一关联基础类OneToOne，才返回父关联模型对象
#425 