### PR TITLE
优化模型嵌套访问一对一关联模型

### DIFF
--- a/src/model/concern/RelationShip.php
+++ b/src/model/concern/RelationShip.php
@@ -760,8 +760,9 @@ trait RelationShip
         if (
             $this->parent && !$modelRelation->isSelfRelation()
             && get_class($this->parent) == get_class($modelRelation->getModel())
-            && $modelRelation instanceof OneToOne
+            && ($modelRelation instanceof OneToOne || $modelRelation instanceof HasOneThrough || $modelRelation instanceof MorphTo || $modelRelation instanceof MorphOne)
         ) {
+            if(empty($this->parent->parent)) $this->parent->parent = $this;
             return $this->parent;
         }
 


### PR DESCRIPTION
1.判断条件加上所有属于一对一关联模型，OneToOne、HasOneThrough、MorphTo、MorphOne
2.优化以上一对一嵌套访问，不重新查询数据库，直接返回父实例 #426 #425 