### PR TITLE
修复 当 $fields 字段非索引数组, 获取器 $value 字段值为 null

### DIFF
--- a/src/db/concern/ModelRelationQuery.php
+++ b/src/db/concern/ModelRelationQuery.php
@@ -8,7 +8,7 @@
 // +----------------------------------------------------------------------
 // | Author: liu21st <liu21st@gmail.com>
 // +----------------------------------------------------------------------
-declare (strict_types = 1);
+declare(strict_types=1);
 
 namespace think\db\concern;
 
@@ -166,9 +166,9 @@ trait ModelRelationQuery
                 $method    = 'search' . Str::studly($fieldName) . 'Attr';
 
                 if (method_exists($this->model, $method)) {
-                    $this->model->$method($this, $data[$field] ?? null, $data, $prefix);
-                } elseif (isset($data[$field])) {
-                    $this->where($fieldName, in_array($fieldName, $likeFields) ? 'like' : '=', in_array($fieldName, $likeFields) ? '%' . $data[$field] . '%' : $data[$field]);
+                    $this->model->$method($this, $data[$fieldName] ?? null, $data, $prefix);
+                } elseif (isset($data[$fieldName])) {
+                    $this->where($fieldName, in_array($fieldName, $likeFields) ? 'like' : '=', in_array($fieldName, $likeFields) ? '%' . $data[$fieldName] . '%' : $data[$fieldName]);
                 }
             }
         }
@@ -198,7 +198,6 @@ trait ModelRelationQuery
             [$relation, $field] = explode('.', $name);
 
             if (!empty($this->options['json']) && in_array($relation, $this->options['json'])) {
-
             } else {
                 $this->options['with_relation_attr'][$relation][$field] = $callback;
                 unset($this->options['with_attr'][$name]);
@@ -558,5 +557,4 @@ trait ModelRelationQuery
         // 刷新原始数据
         $result->refreshOrigin();
     }
-
 }


### PR DESCRIPTION
### 描述:
使用搜索器 `withSearch` 查询时, 当 `$fields` 和 `$data` 字段传入相同值, 对应的搜索器获取到的 `$value` 为 `null`

### 重现步骤:
```php
<?php

namespace app\model;

use think\Model;

class User extends Model
{
    public function searchNameAttr($query, $value, $data)
    {
        var_dump($value, $data);
    }
}

```

```php
<?php

use app\model\User;

$where = [
    'name' => 'test'
];

User::withSearch($where, $where)->select();

// NULL
// array(1) {
//   ["name"]=>
//   string(4) "test"
// }
```