### PR TITLE
修复 当 $fields 字段非索引数组, 获取器 $value 字段值为 null

### DIFF
--- a/src/db/concern/ModelRelationQuery.php
+++ b/src/db/concern/ModelRelationQuery.php
@@ -173,13 +173,13 @@ trait ModelRelationQuery
                 $field($this, $data[$key] ?? null, $data, $prefix);
             } elseif ($this->model) {
                 // 检测搜索器
-                $fieldName = is_numeric($key) ? $field : $key;
+                $fieldName = is_int($key) ? $field : $key;
                 $method = 'search' . Str::studly($fieldName) . 'Attr';
 
                 if (method_exists($this->model, $method)) {
-                    $this->model->$method($this, $data[$field] ?? null, $data, $prefix);
-                } elseif (isset($data[$field])) {
-                    $this->where($fieldName, in_array($fieldName, $likeFields) ? 'like' : '=', in_array($fieldName, $likeFields) ? '%' . $data[$field] . '%' : $data[$field]);
+                    $this->model->$method($this, $data[$fieldName] ?? null, $data, $prefix);
+                } elseif (isset($data[$fieldName])) {
+                    $this->where($fieldName, in_array($fieldName, $likeFields) ? 'like' : '=', in_array($fieldName, $likeFields) ? '%' . $data[$fieldName] . '%' : $data[$fieldName]);
                 }
             }
         }


### PR DESCRIPTION
### 描述:
使用搜索器 `withSearch` 查询时, 当 `$fields` 和 `$data` 字段传入相同值, 对应的搜索器获取到的 `$value` 为 `null`

### 重现步骤:
```php
<?php

namespace app\model;

use think\Model;

class User extends Model
{
    public function searchNameAttr($query, $value, $data)
    {
        var_dump($value, $data);
    }
}

```

```php
<?php

use app\model\User;

$where = [
    'name' => 'test'
];

User::withSearch($where, $where)->select();

// NULL
// array(1) {
//   ["name"]=>
//   string(4) "test"
// }
```