### PR TITLE
修复模型设置类型转换为array时的bug

### DIFF
--- a/src/model/concern/Attribute.php
+++ b/src/model/concern/Attribute.php
@@ -461,7 +461,7 @@ trait Attribute
             'timestamp' =>  !is_numeric($value) ? strtotime($value) : $value,
             'datetime'  =>  $this->formatDateTime('Y-m-d H:i:s.u', $value, true),
             'object'    =>  is_object($value) ? json_encode($value, JSON_FORCE_OBJECT) : $value,
-            'array'     =>  (array) $value,
+            'array'     =>  json_encode((array) $value, !empty($param) ? (int) $param : JSON_UNESCAPED_UNICODE),
             'json'      =>  json_encode((array) $value, !empty($param) ? (int) $param : JSON_UNESCAPED_UNICODE),
             'serialize' =>  serialize($value),
             default     =>  $value instanceof Stringable && str_contains($type, '\\') ? $value->__toString() : $value,


### PR DESCRIPTION
老版本使用switch时，case 'array'没有break，导致执行了default的__toString。。。
新版本使用的match
![9a74b5ac36b6a92b7b7c9f09d0a1c30](https://user-images.githubusercontent.com/127706674/227830906-33e25682-a912-42bb-a666-8612a779e1d0.png)
![a844986234b99ca674f8817146b190e](https://user-images.githubusercontent.com/127706674/227830915-ae702d5f-dcc5-413b-b95f-fb0dc010ed8a.png)
#433 