### PR TITLE
清理冗余、修改权限、添加返回类型和参数类型

### DIFF
--- a/src/model/concern/SoftDelete.php
+++ b/src/model/concern/SoftDelete.php
@@ -199,7 +199,7 @@ trait SoftDelete
      *
      * @return string|false
      */
-    protected function getDeleteTimeField(bool $read = false)
+    public function getDeleteTimeField(bool $read = false): bool|string
     {
         $field = property_exists($this, 'deleteTime') && isset($this->deleteTime) ? $this->deleteTime : 'delete_time';
 

--- a/src/model/concern/SoftDelete.php
+++ b/src/model/concern/SoftDelete.php
@@ -17,7 +17,7 @@ use think\db\BaseQuery as Query;
 use think\Model;
 
 /**
- * 数据软删除.
+ * 数据软删除
  *
  * @mixin Model
  *
@@ -147,8 +147,6 @@ trait SoftDelete
         } elseif ($data instanceof \Closure) {
             call_user_func_array($data, [&$query]);
             $data = [];
-        } elseif (is_null($data)) {
-            return false;
         }
 
         $resultSet = $query->select((array) $data);

--- a/src/model/concern/SoftDelete.php
+++ b/src/model/concern/SoftDelete.php
@@ -50,12 +50,12 @@ trait SoftDelete
         return false;
     }
 
-    public function scopeWithTrashed(Query $query)
+    public function scopeWithTrashed(Query $query): void
     {
         $query->removeOption('soft_delete');
     }
 
-    public function scopeOnlyTrashed(Query $query)
+    public function scopeOnlyTrashed(Query $query): void
     {
         $field = $this->getDeleteTimeField(true);
 
@@ -166,7 +166,7 @@ trait SoftDelete
      *
      * @return bool
      */
-    public function restore($where = []): bool
+    public function restore(array $where = []): bool
     {
         $name = $this->getDeleteTimeField();
 


### PR DESCRIPTION
### 清理冗余

132 行的 `if (empty($data) && 0 !== $data)` 已条件成立，结束运行(`return false`)
![image](https://user-images.githubusercontent.com/9215157/228147690-4e174472-67d0-4bc4-911d-541085ba4223.png)

### 修改权限

可以获取软删除字段，用于恢复数据时，限制只恢复指定删除时间的数据。
恢复主模型数据时，需要恢复关联模型的数据。但关联模型的数据有些比主模型删除早，所以需要限制只恢复比主模型删除晚的关联模型数据。
而能获取软删除字段能很好的提升写法的灵活性。

### 添加返回类型和参数类型