### PR TITLE
多态类型未定义时，返回null

### DIFF
--- a/src/model/relation/MorphTo.php
+++ b/src/model/relation/MorphTo.php
@@ -104,7 +104,7 @@ class MorphTo extends Relation
         // 主键数据
         $pk = $this->parent->$morphKey;
 
-        $relationModel = $this->buildQuery((new $model())->relation($subRelation))->find($pk);
+        $relationModel = class_exists($model) ? $this->buildQuery((new $model())->relation($subRelation))->find($pk) : null;
 
         if ($relationModel) {
             $relationModel->setParent(clone $this->parent);


### PR DESCRIPTION
修改多态关联 延迟获取关联数据，多态类型未定义时，返回null。和预载入查询保持一致
![image](https://user-images.githubusercontent.com/127706674/228151003-db75fa09-d302-494c-ac10-718b51c0ed36.png)
