### PR TITLE
修复关联输出显示和隐藏不生效BUG

### DIFF
--- a/src/model/concern/Conversion.php
+++ b/src/model/concern/Conversion.php
@@ -233,6 +233,8 @@ trait Conversion
                     $visible[$val] = true;
                     $hasVisible = true;
                 }
+            } else {
+                $visible[$key] = $val;
             }
         }
 
@@ -244,6 +246,8 @@ trait Conversion
                 } else {
                     $hidden[$val] = true;
                 }
+            } else {
+                $hidden[$key] = $val;
             }
         }
 


### PR DESCRIPTION
根据文档中所描述的，关联输出可以这样设置：
```php
$list = User::with('profile')->select();
$list->visible(['profile' => ['address','phone','email']])->toArray();
```
而在 https://github.com/top-think/think-orm/commit/f405b530bb9f172cca3b7af6a9e2b96ceb44fce8 中破坏了这种兼容性。