### PR TITLE
3.0 $query to $mongoQuery

### DIFF
--- a/src/db/connector/Mongo.php
+++ b/src/db/connector/Mongo.php
@@ -263,7 +263,7 @@ class Mongo extends Connection
         $this->queryStartTime = microtime(true);
 
         if ($session = $this->getSession()) {
-            $this->cursor = $this->mongo->executeQuery($namespace, $query, [
+            $this->cursor = $this->mongo->executeQuery($namespace, $mongoQuery, [
                 'readPreference' => is_null($readPreference) ? new ReadPreference(ReadPreference::RP_PRIMARY) : $readPreference,
                 'session'        => $session,
             ]);


### PR DESCRIPTION
与 2.0一样的问题。目前在2.0上可正常使用。