### PR TITLE
修改 PHPDOC 中的 PDOException 异常命名空间

### DIFF
--- a/src/db/concern/Transaction.php
+++ b/src/db/concern/Transaction.php
@@ -24,7 +24,7 @@ trait Transaction
      * @param callable $callback 数据操作方法回调
      * @param array    $dbs      多个查询对象或者连接对象
      *
-     * @throws PDOException
+     * @throws \PDOException
      * @throws \Exception
      * @throws \Throwable
      *
@@ -60,7 +60,7 @@ trait Transaction
     /**
      * 用于非自动提交状态下面的查询提交.
      *
-     * @throws PDOException
+     * @throws \PDOException
      *
      * @return void
      */
@@ -72,7 +72,7 @@ trait Transaction
     /**
      * 事务回滚.
      *
-     * @throws PDOException
+     * @throws \PDOException
      *
      * @return void
      */


### PR DESCRIPTION
* 抛出的异常并非think\db\concern\PDOException