### PR TITLE
删除 phpunit 中的 -v 参数

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Run test suite
-        run: composer exec -- phpunit -v
+        run: composer exec -- phpunit
         env:
           TESTS_DB_MYSQL_HOST: 127.0.0.1
           TESTS_DB_MYSQL_PORT: 3306


### PR DESCRIPTION
* phpunit从10开始不再支持此参数，加上也没有效果

* phpunit从10.2.4开始，删除了此参数，加上就报错

* The short option `-v` (short for `--verbose`)  was still accepted by the test runner, but no longer had an effect since `--verbose` was removed in PHPUnit 10.0