### PR TITLE
支持 json 类型值的 null，not null判断

### DIFF
--- a/src/db/builder/Mysql.php
+++ b/src/db/builder/Mysql.php
@@ -422,6 +422,31 @@ class Mysql extends Builder
     }
 
     /**
+     * Null查询.
+     *
+     * @param Query  $query    查询对象
+     * @param string $key
+     * @param string $exp
+     * @param mixed  $value
+     * @param string $field
+     * @param int    $bindType
+     *
+     * @return string
+     */
+    protected function parseNull(Query $query, string $key, string $exp, $value, $field, int $bindType): string
+    {
+        if (str_starts_with($key, "json_extract")) {
+            if ($exp === 'NULL') {
+                return '(' . $key . ' is null OR json_type(' . $key . ') = \'NULL\')';
+            }elseif ($exp === 'NOT NULL'){
+                return '(' . $key . ' is not null AND json_type(' . $key . ') != \'NULL\')';
+            }
+        }
+
+        return parent::parseNull($query, $key, $exp, $value, $field, $bindType);
+    }
+
+    /**
      * 随机排序.
      *
      * @param Query $query 查询对象

--- a/tests/orm/DbJsonFieldsTest.php
+++ b/tests/orm/DbJsonFieldsTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace tests\orm;
+
+use tests\Base;
+use think\Collection;
+use think\facade\Db;
+
+class DbJsonFieldsTest extends Base
+{
+    protected static string $table = 'test_goods';
+
+    protected static array $testGoodsData;
+
+    protected static Collection $testGoodsDataCollect;
+
+    public static function setUpBeforeClass(): void
+    {
+        Db::execute('DROP TABLE IF EXISTS `' . self::$table . '`;');
+        Db::execute(
+            <<<'SQL'
+CREATE TABLE `test_goods` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `extend` json DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+SQL
+        );
+    }
+
+    public function setUp(): void
+    {
+        Db::execute('TRUNCATE TABLE `' . self::$table . '`;');
+        $data = [
+            ['id' => 1, 'name' => '肥皂', 'extend' => '{"brand": "TP6", "standard": null, "type": "清洁"}'],
+            ['id' => 2, 'name' => '牙膏', 'extend' => '{"brand": "TP8", "standard": "大", "type": "清洁"}'],
+            ['id' => 3, 'name' => '牙刷', 'extend' => '{"brand": "TP8", "standard": "大", "type": "清洁"}'],
+            ['id' => 4, 'name' => '卫生纸', 'extend' => '{"brand": null, "standard": null, "type": "日用品" ,"amount": 20}'],
+            ['id' => 5, 'name' => '香肠', 'extend' => '{"brand": null, "weight": 480, "type": "食品" ,"pack": 1}'],
+        ];
+        self::$testGoodsData = $data;
+        foreach ($data as &$item) {
+            $item['extend'] = json_decode($item['extend'], true);
+        }
+        self::$testGoodsDataCollect = collect($data);
+        Db::table(self::$table)->insertAll(self::$testGoodsData);
+    }
+
+    /**
+     * @test 测试当 json 字段的指定成员不存在
+     */
+    public function testJsonFieldMemberNotExists()
+    {
+        $data = Db::table(self::$table)->where('extend->weight', null)->select();
+        $this->assertSame($data->count(), self::$testGoodsDataCollect->where('extend.weight', null)->count());
+
+        $data = Db::table(self::$table)->where('extend->amount', null)->select();
+        $this->assertSame($data->count(), self::$testGoodsDataCollect->where('extend.amount', null)->count());
+
+        $data = Db::table(self::$table)->where('extend->pack', null)->select();
+        $this->assertSame($data->count(), self::$testGoodsDataCollect->where('extend.pack', null)->count());
+    }
+
+    /**
+     * @test 测试当 json 字段的指定成员不存在或为 null
+     */
+    public function testJsonFieldMemberNotExistsOrNull()
+    {
+        $data = Db::table(self::$table)->where('extend->brand', null)->select();
+        $this->assertSame($data->count(), self::$testGoodsDataCollect->where('extend.brand', null)->count());
+
+        $data = Db::table(self::$table)->where('extend->standard', null)->select();
+        $this->assertSame($data->count(), self::$testGoodsDataCollect->where('extend.standard', null)->count());
+    }
+
+    /**
+     * @test 测试搜索 json 字段指定成员为指定的值
+     */
+    public function testJsonFieldMemberEqual()
+    {
+        $data = Db::table(self::$table)->where('extend->brand', 'TP8')->select();
+        $this->assertSame($data->count(), self::$testGoodsDataCollect->where('extend.brand', 'TP8')->count());
+
+        $data = Db::table(self::$table)->where('extend->standard', '大')->select();
+        $this->assertSame($data->count(), self::$testGoodsDataCollect->where('extend.standard', '大')->count());
+
+        $data = Db::table(self::$table)->where('extend->type', '清洁')->select();
+        $this->assertSame($data->count(), self::$testGoodsDataCollect->where('extend.type', '清洁')->count());
+    }
+
+    /**
+     * @test 测试搜索 json 字段指定成员不为指定的值
+     */
+    public function testJsonFieldMemberNotEqual()
+    {
+        $data = Db::table(self::$table)->where('extend->brand', '<>', 'TP8')->whereNull('extend->brand', "or")->select();
+        $this->assertSame($data->count(), self::$testGoodsDataCollect->where('extend.brand', '<>', 'TP8')->count());
+
+        $data = Db::table(self::$table)->where('extend->standard', '<>', '大')->whereNull('extend->standard', "or")->select();
+        $this->assertSame($data->count(), self::$testGoodsDataCollect->where('extend.standard', '<>', '大')->count());
+
+        $data = Db::table(self::$table)->where('extend->type', '<>', '清洁')->whereNull('extend->type', "or")->select();
+        $this->assertSame($data->count(), self::$testGoodsDataCollect->where('extend.type', '<>', '清洁')->count());
+    }
+}


### PR DESCRIPTION
* 当前的判断，仅对`json`元素是否存在做了判断，没有对`json`中的值进行判断

如：
```json
{
    "name":null,
    "test":123
}
```
通过`whereNull("fields->name")`是无法查询出来的