### PR TITLE
Update Db.php

### DIFF
--- a/src/facade/Db.php
+++ b/src/facade/Db.php
@@ -17,6 +17,7 @@ use think\Facade;
 /**
  * @see \think\DbManager
  * @mixin \think\DbManager
+ * @method static query(string $sql, array $bind = [], bool $master = false, bool $pdo = false) 执行查询 返回数据集
  */
 class Db extends Facade
 {


### PR DESCRIPTION
使用phpstrom会提示 

```
方法 'query' 在 \think\facade\Db 中未找到 
```

添加这行注释之后就不会提示了