### PR TITLE
一对一关联时,关联的key获取不准确

### DIFF
--- a/src/db/builder/Dm.php
+++ b/src/db/builder/Dm.php
@@ -1,0 +1,117 @@
+<?php
+// +----------------------------------------------------------------------
+// | ThinkPHP [ WE CAN DO IT JUST THINK ]
+// +----------------------------------------------------------------------
+// | Licensed ( http://www.apache.org/licenses/LICENSE-2.0 )
+// +----------------------------------------------------------------------
+// | Author: liu21st <liu21st@gmail.com>
+// +----------------------------------------------------------------------
+declare (strict_types = 1);
+
+namespace think\db\builder;
+
+use think\db\Builder;
+use think\db\Query;
+use think\db\exception\DbException as Exception;
+use think\db\Raw;
+
+/**
+ * Oracle数据库驱动
+ */
+class Dm extends Builder
+{
+//    protected $selectSql = 'SELECT * FROM (SELECT thinkphp.*, rownum AS numrow FROM (SELECT  %DISTINCT% %FIELD% FROM %TABLE%%JOIN%%WHERE%%GROUP%%HAVING%%ORDER%) thinkphp ) %LIMIT%%COMMENT%';
+
+    /**
+     * limit分析
+     * @access protected
+     * @param  Query $query 查询对象
+     * @param  mixed $limit
+     * @return string
+     */
+    protected function parseLimit(Query $query, string $limit): string
+    {
+        return (!empty($limit) && false === strpos($limit, '(')) ? ' LIMIT ' . $limit . ' ' : '';
+
+    }
+
+    /**
+     * 设置锁机制
+     * @access protected
+     * @param  Query      $query 查询对象
+     * @param  bool|false $lock
+     * @return string
+     */
+    protected function parseLock(Query $query, $lock = false): string
+    {
+        if (!$lock) {
+            return '';
+        }
+
+        return ' FOR UPDATE NOWAIT ';
+    }
+
+    /**
+     * 字段和表名处理
+     * @access public
+     * @param Query $query 查询对象
+     * @param string $key
+     * @param bool $strict
+     * @return string
+     * @throws Exception
+     */
+    public function parseKey(Query $query, $key, bool $strict = false): string
+    {
+        if (is_int($key)) {
+            return (string) $key;
+        } elseif ($key instanceof Raw) {
+            return $this->parseRaw($query, $key);
+        }
+
+        $key = trim($key);
+
+        if (strpos($key, '->') && false === strpos($key, '(')) {
+            // JSON字段支持
+            [$field, $name] = explode($key, '->');
+            $key            = $field . '."' . $name . '"';
+        } elseif (strpos($key, '.') && !preg_match('/[,\'\"\(\)\[\s]/', $key)) {
+            [$table, $key] = explode('.', $key, 2);
+
+            $alias = $query->getOptions('alias');
+
+            if ('__TABLE__' == $table) {
+                $table = $query->getOptions('table');
+                $table = is_array($table) ? array_shift($table) : $table;
+            }
+
+            if (isset($alias[$table])) {
+                $table = $alias[$table];
+            }
+        }
+
+        if ($strict && !preg_match('/^[\w\.\*]+$/', $key)) {
+            throw new Exception('not support data:' . $key);
+        }
+
+        if ('*' != $key && !preg_match('/[,\'\"\*\(\)\[.\s]/', $key)) {
+            $key = '"' . $key . '"';
+        }
+
+        if (isset($table)) {
+            $key = '"' . $table . '".' . $key;
+        }
+
+        return $key;
+    }
+
+    /**
+     * 随机排序
+     * @access protected
+     * @param  Query $query 查询对象
+     * @return string
+     */
+    protected function parseRand(Query $query): string
+    {
+        return 'DBMS_RANDOM.value';
+    }
+}

--- a/src/db/connector/Dm.php
+++ b/src/db/connector/Dm.php
@@ -30,7 +30,7 @@ class Dm extends PDOConnection
      */
     protected function parseDsn(array $config): string
     {
-        $dsn = sprintf("dm:host=%s;port=%s;dbname=%s", $config['hostname'] ,$config['hostport'] , $config['database']);
+        $dsn = sprintf("dm:host=%s;port=%s;dbname=%s", $config['hostname'], $config['hostport'], $config['database']);
         return  $dsn;
     }
     /**
@@ -42,7 +42,7 @@ class Dm extends PDOConnection
      * @return PDO
      * @throws PDOException
      */
-    public function connect(array $config = [], $linkNum = 0, $autoConnection = false): PDO{
+    public function connect(array $config = [], $linkNum = 0, $autoConnection = false): PDO {
         if (empty($config)) {
             $config = $this->config;
         } else {
@@ -56,7 +56,6 @@ class Dm extends PDOConnection
 
     }
 
-
     /**
      * 取得数据表的字段信息
      * @access public
@@ -65,11 +64,11 @@ class Dm extends PDOConnection
      */
     public function getFields(string $tableName): array
     {
-        $tableName=str_replace("`","",$tableName);
+        $tableName=str_replace("`", "", $tableName);
 
         $sql    =  $sql=sprintf("
 select a.column_name,data_type,decode(nullable,'Y',0,1) notnull,data_default,decode(a.column_name,b.column_name,1,0) pk from user_tab_columns a,(select column_name from user_constraints c,user_cons_columns col where c.constraint_name=col.constraint_name and c.constraint_type='P'and c.table_name='%s') b where table_name='%s' and a.column_name=b.column_name(+)
-",$tableName,$tableName);
+", $tableName, $tableName);
 
         $pdo    = $this->getPDOStatement($sql);
         $result = $pdo->fetchAll(PDO::FETCH_ASSOC);
@@ -84,8 +83,8 @@ select a.column_name,data_type,decode(nullable,'Y',0,1) notnull,data_default,dec
                     'type'    => $val['data_type'],
                     'notnull' => 1 == $val['notnull'],
                     'default' => $val['data_default'],
-                    'primary' => $val['pk']==1,
-                    'autoinc' =>  $val['pk']==1,
+                    'primary' => $val['pk'] == 1,
+                    'autoinc' =>  $val['pk'] == 1,
                     'comment' => '',
                 ];
             }

--- a/src/db/connector/Dm.php
+++ b/src/db/connector/Dm.php
@@ -1,0 +1,134 @@
+<?php
+// +----------------------------------------------------------------------
+// | ThinkPHP [ WE CAN DO IT JUST THINK ]
+// +----------------------------------------------------------------------
+// | Copyright (c) 2006~2019 http://thinkphp.cn All rights reserved.
+// +----------------------------------------------------------------------
+// | Licensed ( http://www.apache.org/licenses/LICENSE-2.0 )
+// +----------------------------------------------------------------------
+// | Author: liu21st <liu21st@gmail.com>
+// +----------------------------------------------------------------------
+declare (strict_types = 1);
+
+namespace think\db\connector;
+
+use PDO;
+use think\db\exception\PDOException;
+use think\db\PDOConnection;
+
+/**
+ * mysql数据库驱动
+ */
+class Dm extends PDOConnection
+{
+
+    /**
+     * 解析pdo连接的dsn信息
+     * @access protected
+     * @param  array $config 连接信息
+     * @return string
+     */
+    protected function parseDsn(array $config): string
+    {
+        $dsn = sprintf("dm:host=%s;port=%s;dbname=%s", $config['hostname'] ,$config['hostport'] , $config['database']);
+        return  $dsn;
+    }
+    /**
+     * 连接数据库方法
+     * @access public
+     * @param array      $config         连接参数
+     * @param integer    $linkNum        连接序号
+     * @param array|bool $autoConnection 是否自动连接主数据库（用于分布式）
+     * @return PDO
+     * @throws PDOException
+     */
+    public function connect(array $config = [], $linkNum = 0, $autoConnection = false): PDO{
+        if (empty($config)) {
+            $config = $this->config;
+        } else {
+            $config = array_merge($this->config, $config);
+        }
+        
+        $PDO = parent::connect($config, $linkNum, $autoConnection);
+
+        $PDO->query(sprintf("SET SCHEMA  %s", $config['database']));
+        return $PDO;
+
+    }
+
+
+    /**
+     * 取得数据表的字段信息
+     * @access public
+     * @param  string $tableName
+     * @return array
+     */
+    public function getFields(string $tableName): array
+    {
+        $tableName=str_replace("`","",$tableName);
+
+        $sql    =  $sql=sprintf("
+select a.column_name,data_type,decode(nullable,'Y',0,1) notnull,data_default,decode(a.column_name,b.column_name,1,0) pk from user_tab_columns a,(select column_name from user_constraints c,user_cons_columns col where c.constraint_name=col.constraint_name and c.constraint_type='P'and c.table_name='%s') b where table_name='%s' and a.column_name=b.column_name(+)
+",$tableName,$tableName);
+
+        $pdo    = $this->getPDOStatement($sql);
+        $result = $pdo->fetchAll(PDO::FETCH_ASSOC);
+        $info   = [];
+
+        if (!empty($result)) {
+            foreach ($result as $key => $val) {
+                $val = array_change_key_case($val);
+
+                $info[$val['column_name']] = [
+                    'name'    => $val['column_name'],
+                    'type'    => $val['data_type'],
+                    'notnull' => 1 == $val['notnull'],
+                    'default' => $val['data_default'],
+                    'primary' => $val['pk']==1,
+                    'autoinc' =>  $val['pk']==1,
+                    'comment' => '',
+                ];
+            }
+        }
+
+        return $this->fieldCase($info);
+    }
+
+    /**
+     * 取得数据库的表信息
+     * @access public
+     * @param  string $dbName
+     * @return array
+     */
+    public function getTables(string $dbName = ''): array
+    {
+        $sql    =" SELECT table_name FROM USER_TABLES  where TABLESPACE_NAME='MAIN'";
+        $pdo    = $this->getPDOStatement($sql);
+        $result = $pdo->fetchAll(PDO::FETCH_ASSOC);
+        $info   = [];
+
+        foreach ($result as $key => $val) {
+            $info[$key] = current($val);
+        }
+
+        return $info;
+    }
+
+    protected function supportSavepoint(): bool
+    {
+        return true;
+    }
+
+    /**
+     * 启动XA事务
+     * @access public
+     * @param  string $xid XA事务id
+     * @return void
+     */
+    public function startTransXa(string $xid): void
+    {
+        $this->initConnect(true);
+        $this->linkID->exec("XA START '$xid'");
+    }
+
+}

--- a/src/db/connector/pgsql.sql
+++ b/src/db/connector/pgsql.sql
@@ -58,7 +58,7 @@ BEGIN
            CASE WHEN pg_attribute.attnotnull  THEN ''not null''
            ELSE ''''
            END AS fields_not_null,
-           pg_attrdef.adsrc AS fields_default,
+           pg_get_expr(pg_attrdef.adbin, pg_attrdef.adrelid) AS fields_default,
            pg_description.description AS fields_comment
      FROM
            pg_attribute

--- a/src/model/relation/OneToOne.php
+++ b/src/model/relation/OneToOne.php
@@ -274,8 +274,8 @@ abstract class OneToOne extends Relation
         foreach ($result->getData() as $key => $val) {
             if (str_contains($key, '__')) {
                 [$name, $attr] = explode('__', $key, 2);
-                if ($name == $relation) {
-                    $list[$name][$attr] = $val;
+                if ($name == strtolower($relation)) {
+                    $list[$relation][$attr] = $val;
                     unset($result->$key);
                 }
             }


### PR DESCRIPTION
如果model 采用 驼峰写法
```
    public function screenOrder(){
        return $this->hasOne(ScreenOrder::class,"screen_order_id","screen_order_id");
    }
```
使用一对一关联时,获取到了转为小写的map的key(screenorder),应该以model中的方法为准比较好(screenOrder)