### PR TITLE
MongoDB驱动增加支持配置builder和query参数，便于开发者自定义Builder和Query类实现

### DIFF
--- a/src/db/connector/Mongo.php
+++ b/src/db/connector/Mongo.php
@@ -94,6 +94,10 @@ class Mongo extends Connection
         'fields_cache'    => false,
         // 监听SQL
         'trigger_sql'     => true,
+        // Builder类
+        'builder'         => '',
+        // Query类
+        'query'           => '',
         // 自动写入时间戳字段
         'auto_timestamp'  => false,
         // 时间字段取出后的默认时间格式
@@ -111,7 +115,7 @@ class Mongo extends Connection
      */
     public function getQueryClass(): string
     {
-        return Query::class;
+        return $this->getConfig('query') ?: Query::class;
     }
 
     /**
@@ -131,7 +135,7 @@ class Mongo extends Connection
      */
     public function getBuilderClass(): string
     {
-        return Builder::class;
+        return $this->getConfig('builder') ?: Builder::class;
     }
 
     /**


### PR DESCRIPTION
# 起因
官方文档[数据库驱动](https://doc.thinkphp.cn/v8_0/db_driver.html)中写到： 一旦自定义了数据库驱动，例如你自定义实现了think\mongo\Connection你需要在数据库配置文件中配置：
```php
'type'  =>   'think\mongo\Connection',
'query' =>   'think\mongo\Query',
```
而官方MongoDB驱动却不能通过配置`query`参数实现自定义`Query`类，必须通过重写Connector::getQueryClass()方法才能实现自定义`Query`类，当然要自定义`Builder`类也是如此。

# 结果
于是参照官方`PDOConnection`增加`query`和`builder`参数，同时修改对应获得两个类的方法实现修改参数即可自定义驱动，保持与官方文档一致。