### PR TITLE
修复关联对象动态设置表后缀之后写入数据时不自动添加数据表后缀的问题

### DIFF
--- a/src/model/relation/HasMany.php
+++ b/src/model/relation/HasMany.php
@@ -265,7 +265,7 @@ class HasMany extends Relation
         // 保存关联表数据
         $data[$this->foreignKey] = $this->parent->{$this->localKey};
 
-        return new $this->model($data);
+        return (new $this->model($data))->setSuffix($this->getModel()->getSuffix());
     }
 
     /**

--- a/src/model/relation/MorphMany.php
+++ b/src/model/relation/MorphMany.php
@@ -325,7 +325,7 @@ class MorphMany extends Relation
         $data[$this->morphKey]  = $this->parent->$pk;
         $data[$this->morphType] = $this->type;
 
-        return new $this->model($data);
+        return (new $this->model($data))->setSuffix($this->getModel()->getSuffix());
     }
 
     /**

--- a/src/model/relation/MorphOne.php
+++ b/src/model/relation/MorphOne.php
@@ -300,7 +300,7 @@ class MorphOne extends Relation
         $data[$this->morphKey]  = $this->parent->$pk;
         $data[$this->morphType] = $this->type;
 
-        return new $this->model($data);
+        return (new $this->model($data))->setSuffix($this->getModel()->getSuffix());
     }
 
     /**

--- a/src/model/relation/OneToOne.php
+++ b/src/model/relation/OneToOne.php
@@ -232,7 +232,7 @@ abstract class OneToOne extends Relation
         // 保存关联表数据
         $data[$this->foreignKey] = $this->parent->{$this->localKey};
 
-        return new $this->model($data);
+        return (new $this->model($data))->setSuffix($this->getModel()->getSuffix());
     }
 
     /**


### PR DESCRIPTION
在给模型关联方法中的关联对象动态设置表后缀之后写入数据时，没有在实例化关联模型后给模型实例设置数据表后缀，导致通过关联方法写入关联数据时出现找不到数据表的错误。