### PR TITLE
修复bindValue绑定长整型参数失精度，导致where无法正确匹配数据问题！！！该问题影响了thinkphp目前全部版本

### DIFF
--- a/src/db/PDOConnection.php
+++ b/src/db/PDOConnection.php
@@ -1404,7 +1404,7 @@ abstract class PDOConnection extends Connection
                 if (self::PARAM_INT == $val[1] && '' === $val[0]) {
                     $val[0] = 0;
                 } elseif (self::PARAM_FLOAT == $val[1]) {
-                    $val[0] = is_string($val[0]) ? (float) $val[0] : $val[0];
+                    $val[0] = (is_string($val[0]) && !preg_match("/^\d+(\.\d+)?$/", $val[0]))  ? (float) $val[0] : $val[0];
                     $val[1] = self::PARAM_STR;
                 }
 


### PR DESCRIPTION
修复php转换浮点数导致的精度问题，如 
```php
<?php

$a = '99999999999999';
echo (float)$a; // 99999999999999
$b = '999999999999999';
echo (float)$b; // 999999999999991.0E+15
```
而self::PARAM_FLOAT = 18已经超过了php的15位的长度了，会导致无法where匹配不上长整型的数据
该问题影响了thinkphp目前全部版本