### PR TITLE
whereMonth 获取月份异常

### DIFF
--- a/src/db/concern/TimeFieldQuery.php
+++ b/src/db/concern/TimeFieldQuery.php
@@ -100,6 +100,10 @@ trait TimeFieldQuery
     public function whereMonth(string $field, string $month = 'this month', int $step = 1, string $logic = 'AND')
     {
         if (in_array($month, ['this month', 'last month'])) {
+            if($month === 'last month') {
+                $month = $this->timeRule['last month'][0];
+            }
+
             $month = date('Y-m', strtotime($month));
         }
 


### PR DESCRIPTION
当前日期为 `31` 号，`strtotime('last month')` 获取的并不是上一个月的时间，而是本月的时间。

https://stackoverflow.com/questions/9058523/php-date-and-strtotime-return-wrong-months-on-31st