### PR TITLE
修复数据库类型为mongodb无查询条件时查询不到数据

### DIFF
--- a/src/db/BaseQuery.php
+++ b/src/db/BaseQuery.php
@@ -1355,7 +1355,7 @@ abstract class BaseQuery
             $this->parsePkWhere($data);
         }
 
-        if (empty($this->options['where']) && empty($this->options['order'])) {
+        if (empty($this->options['where']) && empty($this->options['order']) && empty($this->options['sort'])) {
             $result = [];
         } else {
             $result = $this->connection->find($this);


### PR DESCRIPTION
如下查询：Db::name('table')->order('id', 'DESC')->find();
mongodb调用order()方法时不会设置$this->options['order']字段，而是设置$this->options['sort']字段，导致查询失败直接返回[]。