### PR TITLE
潜渊:db/BaseQuery.php

### DIFF
--- a/src/db/BaseQuery.php
+++ b/src/db/BaseQuery.php
@@ -740,15 +740,7 @@ abstract class BaseQuery
 
             $bind   = $this->bind;
             $total  = $this->count();
-            if ($total > 0) {
-                $results = $this->options($options)->bind($bind)->page($page, $listRows)->select();
-            } else {
-                if (!empty($this->model)) {
-                    $results = new \think\model\Collection([]);
-                } else {
-                    $results = new \think\Collection([]);
-                }
-            }
+            $results = $total > 0 ? $this->options($options)->bind($bind)->page($page, $listRows)->select() : $this->select();
         } elseif ($simple) {
             $results    = $this->limit(($page - 1) * $listRows, $listRows + 1)->select();
             $total      = null;


### PR DESCRIPTION
关于使用自定义Collection方法且调用分页功能，列表数据为0时，找不到自定义Collection的扩展方法，从而造成的报错。