### PR TITLE
关于使用自定义Collection方法且调用分页功能，列表数据为0时，找不到自定义Collection的扩展方法，从而造成的报错的修改

### DIFF
--- a/src/db/BaseQuery.php
+++ b/src/db/BaseQuery.php
@@ -740,15 +740,7 @@ abstract class BaseQuery
 
             $bind   = $this->bind;
             $total  = $this->count();
-            if ($total > 0) {
-                $results = $this->options($options)->bind($bind)->page($page, $listRows)->select();
-            } else {
-                if (!empty($this->model)) {
-                    $results = new \think\model\Collection([]);
-                } else {
-                    $results = new \think\Collection([]);
-                }
-            }
+            $results = $total > 0 ? $this->options($options)->bind($bind)->page($page, $listRows)->select() : $this->select();
         } elseif ($simple) {
             $results    = $this->limit(($page - 1) * $listRows, $listRows + 1)->select();
             $total      = null;


### PR DESCRIPTION
关于使用自定义Collection方法且调用分页功能，列表数据为0时，找不到自定义Collection的扩展方法，从而造成的报错。
![image](https://github.com/top-think/think-orm/assets/43459086/ed6301e4-f132-4bcb-9850-da4fd98b76c4)
![image](https://github.com/top-think/think-orm/assets/43459086/7c596974-1f65-4247-99b9-142d8c447889)
![image](https://github.com/top-think/think-orm/assets/43459086/8edfe463-9626-4d76-807e-3865e908378f)
原因是db/BaseQuery.php 数据为零时2.0 版本传入的是[],3.0直接给了个写死的Collection 对象。我这边的解决方式是数据为零给当前模型的数据集。