### PR TITLE
关于使用自定义Collection方法且调用分页功能，列表数据为0时，找不到自定义Collection的扩展方法，从而造成的报错的修改

### DIFF
--- a/src/db/BaseQuery.php
+++ b/src/db/BaseQuery.php
@@ -740,15 +740,7 @@ abstract class BaseQuery
 
             $bind   = $this->bind;
             $total  = $this->count();
-            if ($total > 0) {
-                $results = $this->options($options)->bind($bind)->page($page, $listRows)->select();
-            } else {
-                if (!empty($this->model)) {
-                    $results = new \think\model\Collection([]);
-                } else {
-                    $results = new \think\Collection([]);
-                }
-            }
+            $results = $total > 0 ? $this->options($options)->bind($bind)->page($page, $listRows)->select() : $this->select();
         } elseif ($simple) {
             $results    = $this->limit(($page - 1) * $listRows, $listRows + 1)->select();
             $total      = null;


### PR DESCRIPTION
![image](https://github.com/top-think/think-orm/assets/43459086/891ddcdb-fdb6-42b3-a7f6-aa20e5e4b5fb)
![image](https://github.com/top-think/think-orm/assets/43459086/085dca09-acac-4e4c-9385-acf4aa92bb5d)
![image](https://github.com/top-think/think-orm/assets/43459086/09b88266-697f-4f1d-addd-3159a10c6f88)
