### PR TITLE
关于使用自定义Collection方法且调用分页功能，列表数据为0时，找不到自定义Collection的扩展方法，从而造成的报错的修改

### DIFF
--- a/src/db/BaseQuery.php
+++ b/src/db/BaseQuery.php
@@ -740,15 +740,7 @@ abstract class BaseQuery
 
             $bind = $this->bind;
             $total = $this->count();
-            if ($total > 0) {
-                $results = $this->options($options)->bind($bind)->page($page, $listRows)->select();
-            } else {
-                if (!empty($this->model)) {
-                    $results = new \think\model\Collection([]);
-                } else {
-                    $results = new \think\Collection([]);
-                }
-            }
+            $results = $total > 0 ? $this->options($options)->bind($bind)->page($page, $listRows)->select() : $this->select();
         } elseif ($simple) {
             $results = $this->limit(($page - 1) * $listRows, $listRows + 1)->select();
             $total = null;


### PR DESCRIPTION
![image](https://github.com/top-think/think-orm/assets/43459086/72d185fc-5372-4376-a197-13f0e63dcb2e)
![image](https://github.com/top-think/think-orm/assets/43459086/0d88894e-0bdc-4539-937d-61138f16d8ce)
![image](https://github.com/top-think/think-orm/assets/43459086/9bf156bc-ea94-42d3-9d32-76681dce4a13)
