### PR TITLE
修复PDO链接pgsql数据库遇到已指定自增id时无法成功commit的问题

### DIFF
--- a/src/db/PDOConnection.php
+++ b/src/db/PDOConnection.php
@@ -1749,10 +1749,17 @@ abstract class PDOConnection extends Connection
      */
     public function getLastInsID(BaseQuery $query, string $sequence = null)
     {
-        try {
-            $insertId = $this->linkID->lastInsertId($sequence);
-        } catch (\Exception $e) {
-            $insertId = '';
+        $data = $query->getOptions('data');
+        $pk = $query->getAutoInc();
+        if ($pk && $data[$pk]) {
+            // 已指定主键自增值时直接获取
+            $insertId = (string) $data[$pk];
+        } else {
+            try {
+                $insertId = $this->linkID->lastInsertId($sequence);
+            } catch (\Exception $e) {
+                $insertId = '';
+            }
         }
 
         return $this->autoInsIDType($query, $insertId);


### PR DESCRIPTION
调整PDOConnection.php的getLastInsID方法，以修复PDO链接pgsql数据库遇到已指定自增id时无法成功commit导致添加数据失败