### PR TITLE
修改模型更新方法，默认关闭全局查询范围限制

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -709,7 +709,7 @@ abstract class Model implements JsonSerializable, ArrayAccess, Arrayable, Jsonab
         }
 
         // 模型更新
-        $db = $this->db();
+        $db = $this->db(null);
 
         $db->transaction(function () use ($data, $allowFields, $db) {
             $this->key  = null;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cb9545b7-6828-41cd-acea-a6075a570965)
遇到类似的场景，关闭全局查询范围查询数据，然后更新数据，数据没有更新并且没有任何异常报错。查询范围应该只限制查询场景，如果查询出来，更新操作不应该受影响。