### PR TITLE
优化hasWhere方法

### DIFF
--- a/src/model/relation/BelongsTo.php
+++ b/src/model/relation/BelongsTo.php
@@ -188,16 +188,15 @@ class BelongsTo extends OneToOne
         }
 
         $fields     = $this->getRelationQueryFields($fields, $model);
-        $softDelete = $this->query->getOptions('soft_delete');
         $query      = $query ?: $this->parent->db();
 
         return $query->alias($model)
+            ->via($model)
             ->field($fields)
             ->join([$table => $relation], $model . '.' . $this->foreignKey . '=' . $relation . '.' . $this->localKey, $joinType ?: $this->joinType)
-            ->when($softDelete, function ($query) use ($softDelete, $relation) {
-                $query->where($relation . strstr($softDelete[0], '.'), '=' == $softDelete[1][0] ? $softDelete[1][1] : null);
-            })
-            ->where($where);
+            ->where(function ($query) use ($where) {
+                $query->where($where);
+            });
     }
 
     /**

--- a/src/model/relation/HasMany.php
+++ b/src/model/relation/HasMany.php
@@ -346,17 +346,16 @@ class HasMany extends Relation
         }
 
         $fields = $this->getRelationQueryFields($fields, $model);
-        $softDelete = $this->query->getOptions('soft_delete');
         $query = $query ?: $this->parent->db();
 
         return $query->alias($model)
+            ->via($model)
             ->group($model . '.' . $this->localKey)
             ->field($fields)
             ->join([$table => $relation], $model . '.' . $this->localKey . '=' . $relation . '.' . $this->foreignKey, $joinType)
-            ->when($softDelete, function ($query) use ($softDelete, $relation) {
-                $query->where($relation . strstr($softDelete[0], '.'), '=' == $softDelete[1][0] ? $softDelete[1][1] : null);
-            })
-            ->where($where);
+            ->where(function ($query) use ($where) {
+                $query->where($where);
+            });
     }
 
     /**

--- a/src/model/relation/HasManyThrough.php
+++ b/src/model/relation/HasManyThrough.php
@@ -153,17 +153,16 @@ class HasManyThrough extends Relation
         }
 
         $fields     = $this->getRelationQueryFields($fields, $model);
-        $softDelete = $this->query->getOptions('soft_delete');
         $query      = $query ?: $this->parent->db();
 
         return $query->alias($model)
+            ->via($model)
             ->join($throughTable, $throughTable . '.' . $this->foreignKey . '=' . $model . '.' . $this->localKey)
             ->join($modelTable, $modelTable . '.' . $throughKey . '=' . $throughTable . '.' . $this->throughPk, $joinType)
-            ->when($softDelete, function ($query) use ($softDelete, $modelTable) {
-                $query->where($modelTable . strstr($softDelete[0], '.'), '=' == $softDelete[1][0] ? $softDelete[1][1] : null);
-            })
             ->group($modelTable . '.' . $this->throughKey)
-            ->where($where)
+            ->where(function ($query) use ($where) {
+                $query->where($where);
+            })
             ->field($fields);
     }
 

--- a/src/model/relation/HasOne.php
+++ b/src/model/relation/HasOne.php
@@ -188,16 +188,15 @@ class HasOne extends OneToOne
         }
 
         $fields     = $this->getRelationQueryFields($fields, $model);
-        $softDelete = $this->query->getOptions('soft_delete');
         $query      = $query ?: $this->parent->db();
 
         return $query->alias($model)
+            ->via($model)
             ->field($fields)
             ->join([$table => $relation], $model . '.' . $this->localKey . '=' . $relation . '.' . $this->foreignKey, $joinType ?: $this->joinType)
-            ->when($softDelete, function ($query) use ($softDelete, $relation) {
-                $query->where($relation . strstr($softDelete[0], '.'), '=' == $softDelete[1][0] ? $softDelete[1][1] : null);
-            })
-            ->where($where);
+            ->where(function ($query) use ($where) {
+                $query->where($where);
+            });
     }
 
     /**


### PR DESCRIPTION
1.hasWhere和where方法同时使用，没有自动加别名
![image](https://github.com/user-attachments/assets/72087d67-9c26-4faf-9465-809f58368d67)
![image](https://github.com/user-attachments/assets/13d01cf9-65eb-4482-86b5-8c9a094db7f6)
2.对关联模型的软删除查询有问题，如果hasWhere闭包里写的有or查询会导致软删除查询限制无效
![image](https://github.com/user-attachments/assets/1323278f-c29f-4acc-bdb6-d39dbaa4fbad)
![image](https://github.com/user-attachments/assets/152549b8-1955-48a8-8985-2248a0c7dc4a)
3.where方法传入query类的时候，会清空替换掉前面的查询条件
![image](https://github.com/user-attachments/assets/55cdb1c8-81cd-4470-8fcd-a1a17fb3e5d8)
![image](https://github.com/user-attachments/assets/37a332e9-d2bc-453a-a2d6-2805825035e1)
优化如下：增加默认查询条件下的字段别名，去除关联模型的软删除查询（像withjoin和join都不支持都对关联模型的软删除查询），hasWhere函数内where增加闭包（支持和where方法同时使用）