### PR TITLE
修复远程一对一关联到同一对象时仅成功最后一个的问题

### DIFF
--- a/src/model/relation/HasOneThrough.php
+++ b/src/model/relation/HasOneThrough.php
@@ -151,14 +151,10 @@ class HasOneThrough extends HasManyThrough
             ->select();
 
         // 组装模型数据
-        $data = [];
-        $keys = array_flip($keys);
-
-        foreach ($list as $set) {
-            $data[$keys[$set->{$this->throughKey}]] = $set;
-        }
-
-        return $data;
+        return array_map(function ($key) use ($list) {
+            $set = $list->where($this->throughKey, '=', $key)->first();
+            return $set ? clone $set : null;
+        }, $keys);
     }
 
 }


### PR DESCRIPTION
同 https://github.com/top-think/think-orm/pull/597