### PR TITLE
修复 autoInsIDType函数 数据库无自增主键情况下报错 Illegal offset type

### DIFF
--- a/src/db/PDOConnection.php
+++ b/src/db/PDOConnection.php
@@ -1766,6 +1766,10 @@ abstract class PDOConnection extends Connection
     protected function autoInsIDType(BaseQuery $query, string $insertId)
     {
         $pk = $query->getAutoInc();
+        
+        if (is_array($pk)) {
+            return $insertId;
+        }
 
         if ($pk) {
             $type = $this->getFieldsBind($query->getTable())[$pk];


### PR DESCRIPTION
问题环境：

1. PHP：8.0.2
2.MySQL 8：8.0.12
3.ThinkPHP：8.0
4.Think-ORM：3

数据库表结构
![image](https://github.com/user-attachments/assets/8b69def9-02ff-4870-9b5e-6b9a98676316)

```sql
CREATE TABLE `user` (
  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
  `password` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
  `create_time` int(11) NOT NULL )
ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

ALTER TABLE `user`
  ADD PRIMARY KEY (`name`);
```

控制器代码
![image](https://github.com/user-attachments/assets/87442d93-249d-4842-90f4-0c2d7925d1bd)

报错:
![image](https://github.com/user-attachments/assets/942e95b4-e7b1-40bd-b106-34d572e8a0a9)

问题原因
`
$pk = $query->getAutoInc();
var_dump($pk)
`

没有自增主键返回的表结构数组
![image](https://github.com/user-attachments/assets/3d18d5cf-a3ec-49b3-8ba3-8213358cbdf6)

上层代码
getTableInfo函数
![image](https://github.com/user-attachments/assets/5699c4d8-0634-48d4-a778-4c6ba6c44dd3)


问题修复:添加判断无自增主键情况直接返回
![image](https://github.com/user-attachments/assets/c8fdb5c3-106a-4030-b123-b52fc4988118)


