### PR TITLE
模型的类型转换声明添加字符串支持

### DIFF
--- a/src/model/concern/Attribute.php
+++ b/src/model/concern/Attribute.php
@@ -430,8 +430,8 @@ trait Attribute
             $value = $this->writeTransform($value, $this->type[$name]);
         } elseif ($this->isRelationAttr($name)) {
             // 关联属性
-            $this->relation[$name]  = $value;
-            $this->with[$name]      = true;
+            $this->relation[$name] = $value;
+            $this->with[$name] = true;
         } elseif ((array_key_exists($name, $this->origin) || empty($this->origin)) && $value instanceof Stringable) {
             // 对象类型
             $value = $value->__toString();
@@ -479,17 +479,17 @@ trait Attribute
         };
 
         return match ($type) {
-            'string'    =>  (string) $value,
-            'integer'   =>  (int) $value,
-            'float'     =>  empty($param) ? (float) $value : (float) number_format($value, (int) $param, '.', ''),
-            'boolean'   =>  (bool) $value,
-            'timestamp' =>  !is_numeric($value) ? strtotime($value) : $value,
-            'datetime'  =>  $this->formatDateTime('Y-m-d H:i:s.u', $value, true),
-            'object'    =>  is_object($value) ? json_encode($value, JSON_FORCE_OBJECT) : $value,
-            'array'     =>  json_encode((array) $value, !empty($param) ? (int) $param : JSON_UNESCAPED_UNICODE),
-            'json'      =>  json_encode($value, !empty($param) ? (int) $param : JSON_UNESCAPED_UNICODE),
-            'serialize' =>  serialize($value),
-            default     =>  $typeTransform($type, $value, $this),
+            'string' => (string) $value,
+            'integer' => (int) $value,
+            'float' => empty($param) ? (float) $value : (float) number_format($value, (int) $param, '.', ''),
+            'boolean' => (bool) $value,
+            'timestamp' => !is_numeric($value) ? strtotime($value) : $value,
+            'datetime' => $this->formatDateTime('Y-m-d H:i:s.u', $value, true),
+            'object' => is_object($value) ? json_encode($value, JSON_FORCE_OBJECT) : $value,
+            'array' => json_encode((array) $value, !empty($param) ? (int) $param : JSON_UNESCAPED_UNICODE),
+            'json' => json_encode($value, !empty($param) ? (int) $param : JSON_UNESCAPED_UNICODE),
+            'serialize' => serialize($value),
+            default => $typeTransform($type, $value, $this),
         };
     }
 
@@ -505,11 +505,11 @@ trait Attribute
     public function getAttr(string $name)
     {
         try {
-            $relation   = false;
-            $value      = $this->getData($name);
+            $relation = false;
+            $value = $this->getData($name);
         } catch (InvalidArgumentException $e) {
-            $relation   = $this->isRelationAttr($name);
-            $value      = null;
+            $relation = $this->isRelationAttr($name);
+            $value = null;
         }
 
         return $this->getValue($name, $value, $relation);
@@ -653,17 +653,17 @@ trait Attribute
         };
 
         return match ($type) {
-            'string'    =>  (string) $value,
-            'integer'   =>  (int) $value,
-            'float'     =>  empty($param) ? (float) $value : (float) number_format($value, (int) $param, '.', ''),
-            'boolean'   =>  (bool) $value,
-            'timestamp' =>  !is_null($value) ? $this->formatDateTime(!empty($param) ? $param : $this->dateFormat, $value, true) : null,
-            'datetime'  =>  !is_null($value) ? $this->formatDateTime(!empty($param) ? $param : $this->dateFormat, $value) : null,
-            'json'      =>  json_decode($value, true),
-            'array'     =>  empty($value) ? [] : json_decode($value, true),
-            'object'    =>  empty($value) ? new \stdClass() : json_decode($value),
-            'serialize' =>  $call($value),
-            default     =>  $typeTransform($type, $value, $this),
+            'string' => (string) $value,
+            'integer' => (int) $value,
+            'float' => empty($param) ? (float) $value : (float) number_format($value, (int) $param, '.', ''),
+            'boolean' => (bool) $value,
+            'timestamp' => !is_null($value) ? $this->formatDateTime(!empty($param) ? $param : $this->dateFormat, $value, true) : null,
+            'datetime' => !is_null($value) ? $this->formatDateTime(!empty($param) ? $param : $this->dateFormat, $value) : null,
+            'json' => json_decode($value, true),
+            'array' => empty($value) ? [] : json_decode($value, true),
+            'object' => empty($value) ? new \stdClass() : json_decode($value),
+            'serialize' => $call($value),
+            default => $typeTransform($type, $value, $this),
         };
     }
 

--- a/src/model/concern/Attribute.php
+++ b/src/model/concern/Attribute.php
@@ -479,6 +479,7 @@ trait Attribute
         };
 
         return match ($type) {
+            'string'    =>  (string) $value,
             'integer'   =>  (int) $value,
             'float'     =>  empty($param) ? (float) $value : (float) number_format($value, (int) $param, '.', ''),
             'boolean'   =>  (bool) $value,
@@ -652,6 +653,7 @@ trait Attribute
         };
 
         return match ($type) {
+            'string'    =>  (string) $value,
             'integer'   =>  (int) $value,
             'float'     =>  empty($param) ? (float) $value : (float) number_format($value, (int) $param, '.', ''),
             'boolean'   =>  (bool) $value,

--- a/tests/orm/ModelFieldTypeTest.php
+++ b/tests/orm/ModelFieldTypeTest.php
@@ -19,7 +19,8 @@ class ModelFieldTypeTest extends TestCase
 CREATE TABLE `test_field_type` (
      `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
      `t_json` json DEFAULT NULL,
-     `t_php` varchar(512) DEFAULT NULL
+     `t_php` varchar(512) DEFAULT NULL,
+     `bigint` bigint UNSIGNED DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 SQL
         );
@@ -28,9 +29,9 @@ SQL
     public function testFieldTypeSelect()
     {
         $data = [
-            ['id' => 1, 't_json' => '{"num1": 1, "str1": "a"}', 't_php' => (string) (new TestFieldPhpDTO(1, 'a'))],
-            ['id' => 2, 't_json' => '{"num1": 2, "str1": "b"}', 't_php' => (string) (new TestFieldPhpDTO(2, 'b'))],
-            ['id' => 3, 't_json' => '{"num1": 3, "str1": "c"}', 't_php' => (string) (new TestFieldPhpDTO(3, 'c'))],
+            ['id' => 1, 't_json' => '{"num1": 1, "str1": "a"}', 't_php' => (string) (new TestFieldPhpDTO(1, 'a')), 'bigint' => '0'],
+            ['id' => 2, 't_json' => '{"num1": 2, "str1": "b"}', 't_php' => (string) (new TestFieldPhpDTO(2, 'b')), 'bigint' => '244791959321042944'],
+            ['id' => 3, 't_json' => '{"num1": 3, "str1": "c"}', 't_php' => (string) (new TestFieldPhpDTO(3, 'c')), 'bigint' => '18374686479671623679'],
         ];
 
         (new FieldTypeModel())->insertAll($data);
@@ -46,6 +47,7 @@ SQL
         foreach ($result as $index => $item) {
             $this->assertEquals(TestFieldJsonDTO::fromData($data[$index]['t_json']), $item->t_json);
             $this->assertEquals((string) TestFieldPhpDTO::fromData($data[$index]['t_php']), (string) $item->t_php);
+            $this->assertSame($data[$index]['bigint'], $item->bigint);
         }
     }
 

--- a/tests/stubs/FieldTypeModel.php
+++ b/tests/stubs/FieldTypeModel.php
@@ -9,6 +9,7 @@ use think\Model;
  * @property int $id
  * @property TestFieldJsonDTO $t_json
  * @property TestFieldPhpDTO $t_php
+ * @property string $bigint
  */
 class FieldTypeModel extends Model
 {
@@ -21,5 +22,6 @@ class FieldTypeModel extends Model
     protected $type = [
         't_json' => TestFieldJsonDTO::class,
         't_php' => TestFieldPhpDTO::class,
+        'bigint' => 'string',
     ];
 }


### PR DESCRIPTION
某些情况下需要字符串类型转换支持。

比如`bigint`在不同精度下会在字符串或整数间自动切换，提供字符串类型转换后能确保模型取值类型的一致性。