### PR TITLE
修正更新V3.0.25 后 ->column(['SUM(IF(a > 0 , a, b))'], 'fleet_id') 用法报错

### DIFF
--- a/src/db/BaseQuery.php
+++ b/src/db/BaseQuery.php
@@ -416,6 +416,11 @@ abstract class BaseQuery
                 $this->result($item);
                 return $item;
             }
+
+            if (is_array($field) && 1 === count($field)) {
+                $field = current($field);
+            }
+
             $array[$field] = $item;
             if ($this->model && $useModelAttr) {
                 if (!empty($this->options['json'])) {


### PR DESCRIPTION

[V3.0.25](https://github.com/top-think/think-orm/compare/v3.0.24...v3.0.25) 的改动中，导致 `->column(['SUM(IF(total_price>0,total_price,apply_price))'], 'fleet_id')` 用法报错。
```json
{
    "code": 500,
    "msg": "系统错误：Cannot access offset of type array on array",
    "line": 419,
    "file": "vendor/topthink/think-orm/src/db/BaseQuery.php",
    "trace": [
        {
            "function": "think\\db\\{closure}",
            "class": "think\\db\\BaseQuery",
            "type": "->"
        },
        {
            "file": "vendor/topthink/think-orm/src/db/BaseQuery.php",
            "line": 407,
            "function": "array_map"
        },
    ]
}
```

有点曲折，之前是用 `->column('SUM(IF(total_price>0,total_price,apply_price))', 'fleet_id')` 的，返回的是：
```array
[1 => "16.00"]
```

更新某个小版本后，返回的结构变为了：
```array
[
    "SUM(IF(total_price>0,`total_price`,estimate_price))" => "16.00"
    "fleet_id" => 1
]
```

然后我这边把用法改为了  `->column(['SUM(IF(total_price>0,total_price,apply_price))'], 'fleet_id')`，现在这两种方法都用不了了。