### PR TITLE
修复直接使用count(model.*)在mariadb中会报错的问题。

### DIFF
--- a/src/db/concern/ModelRelationQuery.php
+++ b/src/db/concern/ModelRelationQuery.php
@@ -468,7 +468,7 @@ trait ModelRelationQuery
      */
     public function withCount(string | array $relation, bool $subQuery = true)
     {
-        return $this->withAggregate($relation, 'count', '*', $subQuery);
+        return $this->withAggregate($relation, 'count', '', $subQuery);
     }
 
     /**

--- a/src/model/concern/RelationShip.php
+++ b/src/model/concern/RelationShip.php
@@ -428,6 +428,8 @@ trait RelationShip
 
             $relation = Str::camel($relation);
 
+            $field = $field ?: $this->$relation()->getPk();
+
             if ($useSubQuery) {
                 $count = $this->$relation()->getRelationCountQuery($closure, $aggregate, $field, $name);
             } else {


### PR DESCRIPTION
## 具体问题：
withCount拼接的sql语句为count(model_name.\*)，然而mariadb、mysql不支持count(table.\*)语法，导致报错，仅postgresql能够正常执行。

例如：
```php
$organizations = OrganizationModel::with(['creator'])->withCount(['users'])->where('uid', '=', $this->auth->uid)->page($page)->limit($size)->select()->toArray();

```

think-orm最终生成sql为：
```sql
SELECT
  *,(
    SELECT
      COUNT(
      `user_model`.*) AS think_count         // <---***ERROR***
    FROM
      `user` `user_model`
      INNER JOIN `organization_user` ON `organization_user`.`userId` = `user_model`.`uid`
      INNER JOIN `organization` ON `organization`.`id` = `organization_user`.`organizationId` 
    WHERE
      ( ( `organization_user`.`organizationId` = organization.id ) ) 
      AND `user_model`.`deleteTime` IS NULL 
  ) AS `AAA` 
FROM
  `organization` 
WHERE
  `organization`.`deleteTime` IS NULL
```

# 各测试用例

## mariadb 10.2测试结果不通过：
![image](https://github.com/user-attachments/assets/a05a5250-6540-48ba-9ec5-dac494ac87a4)

## mysql 5.7 8.0均测试不通过：
![image](https://github.com/user-attachments/assets/328542f0-9f1d-408f-9eee-6d581ac38b17)


## postgresql 16测试通过：
![image](https://github.com/user-attachments/assets/c97e6aac-8b07-4233-af7a-9deb50d158ad)

