### PR TITLE
find方法返回值类型IDE友好提示

### DIFF
--- a/src/db/BaseQuery.php
+++ b/src/db/BaseQuery.php
@@ -1452,7 +1452,7 @@ abstract class BaseQuery
      * @throws ModelNotFoundException
      * @throws DataNotFoundException
      *
-     * @return mixed
+     * @return static|array|null
      */
     public function find($data = null, ?Closure $closure = null)
     {


### PR DESCRIPTION
phpstorm中模型通过find返回的值没有类型提示，比如模型自定义方法、@property和属性，非常不方便。