### PR TITLE
修复where闭包查询中的回调对象$query丢失alias属性的bug

### DIFF
--- a/src/db/BaseQuery.php
+++ b/src/db/BaseQuery.php
@@ -177,6 +177,10 @@ abstract class BaseQuery
             $query->lazyFields($this->options['lazy_fields']);
         }
 
+        if (isset($this->options['alias'])) {
+            $query->alias($this->options['alias']);
+        }
+
         return $query;
     }
 


### PR DESCRIPTION
3.0.33改进where数组查询后，数组查询都是在闭包内的，但是闭包的$query参数丢失了alias属性。

导致使用了alias后，再使用数组查询，且数组查询内的表名为原始表名时会报错