### PR TITLE
修复同时使用HasMany和HasManyThrough在haswhere中主表名字不一致问题导致sql错误问题（没有详细测试过现在能跑而已）

### DIFF
--- a/src/model/relation/HasManyThrough.php
+++ b/src/model/relation/HasManyThrough.php
@@ -102,7 +102,7 @@ class HasManyThrough extends Relation
      */
     public function has(string $operator = '>=', int $count = 1, string $id = '*', string $joinType = '', ?Query $query = null): Query
     {
-        $model         = Str::snake(class_basename($this->parent));
+        $model         = class_basename($this->parent);
         $throughTable  = $this->through->getTable();
         $pk            = $this->throughPk;
         $throughKey    = $this->throughKey;
@@ -137,7 +137,7 @@ class HasManyThrough extends Relation
      */
     public function hasWhere($where = [], $fields = null, $joinType = '', ?Query $query = null): Query
     {
-        $model        = Str::snake(class_basename($this->parent));
+        $model        = class_basename($this->parent);
         $throughTable = $this->through->getTable();
         $pk           = $this->throughPk;
         $throughKey   = $this->throughKey;


### PR DESCRIPTION
修复同时使用HasMany和HasManyThrough在haswhere中主表名字不一致问题导致sql错误问题（没有详细测试过现在能跑而已）

```php
<?php

namespace app\controller;

use app\BaseController;
use think\Model;
use think\response\Json;

class ZhongDianRenWu extends Model{
    function ZhongDianRenWuChengBanDanWei()
    {
        return $this->hasMany(ZhongDianRenWuChengBanDanWei::Class,'zhong_dian_ren_wu_id');
    }
    function ZhongDianRenWuShangBaoNeiRong()
    {
        return $this->hasManyThrough(ZhongDianRenWuShangBaoNeiRong::Class,  ZhongDianRenWuChengBanDanWei::Class);
    }
}
class ZhongDianRenWuChengBanDanWei extends Model{

}
class ZhongDianRenWuShangBaoNeiRong extends Model{

}

class Index extends BaseController
{
    public function index()
    {
        $zhongYaoRenWuModel = new ZhongDianRenWu();
        $zhongYaoRenWuModel = $zhongYaoRenWuModel->with([
            'ZhongDianRenWuChengBanDanWei',
            'ZhongDianRenWuShangBaoNeiRong',
        ])->haswhere(
            'ZhongDianRenWuChengBanDanWei',[]
        )->haswhere(
            'ZhongDianRenWuShangBaoNeiRong',[]
        )->page(PAGE)->limit(LIMIT)->select();


        return \json($zhongYaoRenWuModel);
    }

}

```

修复前

```sql
SELECT 
    `ZhongDianRenWu`.*, `zhong_dian_ren_wu`.* --  `zhong_dian_ren_wu`.* 会被移除
FROM
    `zhong_dian_ren_wu` `zhong_dian_ren_wu`
        JOIN
    `zhong_dian_ren_wu_cheng_ban_dan_wei` `ZhongDianRenWuChengBanDanWei` ON `ZhongDianRenWu`.`id` = `ZhongDianRenWuChengBanDanWei`.`zhong_dian_ren_wu_id`
        INNER JOIN
    `zhong_dian_ren_wu_cheng_ban_dan_wei` ON `zhong_dian_ren_wu_cheng_ban_dan_wei`.`zhong_dian_ren_wu_id` = `zhong_dian_ren_wu`.`id`
        JOIN
    `zhong_dian_ren_wu_shang_bao_nei_rong` ON `zhong_dian_ren_wu_shang_bao_nei_rong`.`zhong_dian_ren_wu_cheng_ban_dan_wei_id` = `zhong_dian_ren_wu_cheng_ban_dan_wei`.`id`
GROUP BY `zhong_dian_ren_wu_shang_bao_nei_rong`.`zhong_dian_ren_wu_cheng_ban_dan_wei_id`
LIMIT 0 , 20;
```

修复后

```sql
SELECT 
    `ZhongDianRenWu`.*
FROM
    `zhong_dian_ren_wu` `ZhongDianRenWu`
        JOIN
    `zhong_dian_ren_wu_cheng_ban_dan_wei` `ZhongDianRenWuChengBanDanWei` ON `ZhongDianRenWu`.`id` = `ZhongDianRenWuChengBanDanWei`.`zhong_dian_ren_wu_id`
        INNER JOIN
    `zhong_dian_ren_wu_cheng_ban_dan_wei` ON `zhong_dian_ren_wu_cheng_ban_dan_wei`.`zhong_dian_ren_wu_id` = `ZhongDianRenWu`.`id`
        JOIN
    `zhong_dian_ren_wu_shang_bao_nei_rong` ON `zhong_dian_ren_wu_shang_bao_nei_rong`.`zhong_dian_ren_wu_cheng_ban_dan_wei_id` = `zhong_dian_ren_wu_cheng_ban_dan_wei`.`id`
GROUP BY `zhong_dian_ren_wu_shang_bao_nei_rong`.`zhong_dian_ren_wu_cheng_ban_dan_wei_id`
LIMIT 0 , 20;
```