### PR TITLE
修复  $info[$fetch] 值为 NULL 出现赋值异常

### DIFF
--- a/src/db/PDOConnection.php
+++ b/src/db/PDOConnection.php
@@ -425,7 +425,7 @@ abstract class PDOConnection extends Connection
 
         $info = $this->getSchemaInfo($tableName);
 
-        return $fetch && isset($info[$fetch]) ? $info[$fetch] : $info;
+        return $fetch && array_key_exists($fetch, $info) ? $info[$fetch] : $info;
     }
 
     /**


### PR DESCRIPTION
当 $info[$fetch] 中的值为 NULL 时, isset($info[$fetch]) 判断为 false 导致结果异常 例: 一个表不是 id 自增, autoinc 为 NULL