### PR TITLE
步进值支持传入 int，Redis::incrBy() 的参数 2 仅支持 int 类型，目前传入的是 float

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -634,13 +634,13 @@ abstract class Model implements JsonSerializable, ArrayAccess, Arrayable, Jsonab
     /**
      * 字段值增长
      *
-     * @param string $field 字段名
-     * @param float  $step  增长值
-     * @param int    $lazyTime 延迟时间（秒）
+     * @param string    $field    字段名
+     * @param float|int $step     增长值
+     * @param int       $lazyTime 延迟时间（秒）
      *
      * @return $this
      */
-    public function inc(string $field, float $step = 1, int $lazyTime = 0)
+    public function inc(string $field, float|int $step = 1, int $lazyTime = 0)
     {
         return $this->set($field, new Express('+', $step, $lazyTime));
     }
@@ -648,13 +648,13 @@ abstract class Model implements JsonSerializable, ArrayAccess, Arrayable, Jsonab
     /**
      * 字段值减少.
      *
-     * @param string $field 字段名
-     * @param float  $step  增长值
-     * @param int    $lazyTime 延迟时间（秒）
+     * @param string    $field    字段名
+     * @param float|int $step     增长值
+     * @param int       $lazyTime 延迟时间（秒）
      *
      * @return $this
      */
-    public function dec(string $field, float $step = 1, int $lazyTime = 0)
+    public function dec(string $field, float|int $step = 1, int $lazyTime = 0)
     {
         return $this->set($field, new Express('-', $step, $lazyTime));
     }

--- a/src/db/Fetch.php
+++ b/src/db/Fetch.php
@@ -248,13 +248,13 @@ class Fetch
     /**
      * 字段值增长
      *
-     * @param string    $field 字段名
-     * @param float     $step  步进值
+     * @param string    $field    字段名
+     * @param float|int $step     步进值
      * @param int       $lazyTime 延迟时间（秒）
      *
      * @return string
      */
-    public function setInc(string $field, float $step = 1, int $lazyTime = 0)
+    public function setInc(string $field, float|int $step = 1, int $lazyTime = 0)
     {
         return $this->inc($field, $step)->update();
     }
@@ -262,13 +262,13 @@ class Fetch
     /**
      * 字段值减少
      *
-     * @param string    $field 字段名
-     * @param float     $step  步进值
+     * @param string    $field    字段名
+     * @param float|int $step     步进值
      * @param int       $lazyTime 延迟时间（秒）
      *
      * @return string
      */
-    public function setDec(string $field, float $step = 1, int $lazyTime = 0)
+    public function setDec(string $field, float|int $step = 1, int $lazyTime = 0)
     {
         return $this->dec($field, $step)->update();
     }

--- a/src/db/Mongo.php
+++ b/src/db/Mongo.php
@@ -163,12 +163,12 @@ class Mongo extends BaseQuery
     /**
      * 字段值增长
      *
-     * @param string $field 字段名
-     * @param float  $step  增长值
+     * @param string    $field 字段名
+     * @param float|int $step  增长值
      *
      * @return $this
      */
-    public function inc(string $field, float $step = 1)
+    public function inc(string $field, float|int $step = 1)
     {
         $this->options['data'][$field] = ['$inc', $step];
 
@@ -178,12 +178,12 @@ class Mongo extends BaseQuery
     /**
      * 字段值减少.
      *
-     * @param string $field 字段名
-     * @param float  $step  减少值
+     * @param string    $field 字段名
+     * @param float|int $step  减少值
      *
      * @return $this
      */
-    public function dec(string $field, float $step = 1)
+    public function dec(string $field, float|int $step = 1)
     {
         return $this->inc($field, -1 * $step);
     }

--- a/src/db/Query.php
+++ b/src/db/Query.php
@@ -361,13 +361,13 @@ class Query extends BaseQuery
     /**
      * 字段值增长
      *
-     * @param string $field 字段名
-     * @param float  $step  增长值
-     * @param int    $lazyTime 延迟时间（秒）
+     * @param string    $field    字段名
+     * @param float|int $step     增长值
+     * @param int       $lazyTime 延迟时间（秒）
      *
      * @return $this
      */
-    public function inc(string $field, float $step = 1, int $lazyTime = 0)
+    public function inc(string $field, float|int $step = 1, int $lazyTime = 0)
     {
         if ($lazyTime > 0) {
             $step = $this->lazyWrite($field, 'inc', $step, $lazyTime);
@@ -384,13 +384,13 @@ class Query extends BaseQuery
     /**
      * 字段值减少.
      *
-     * @param string $field 字段名
-     * @param float  $step  增长值
-     * @param int    $lazyTime 延迟时间（秒）
+     * @param string    $field    字段名
+     * @param float|int $step     增长值
+     * @param int       $lazyTime 延迟时间（秒）
      *
      * @return $this
      */
-    public function dec(string $field, float $step = 1, int $lazyTime = 0)
+    public function dec(string $field, float|int $step = 1, int $lazyTime = 0)
     {
         if ($lazyTime > 0) {
             $step = $this->lazyWrite($field, 'dec', $step, $lazyTime);
@@ -408,13 +408,13 @@ class Query extends BaseQuery
     /**
      * 字段值增长（支持延迟写入）
      *
-     * @param string    $field 字段名
-     * @param float     $step  步进值
+     * @param string    $field    字段名
+     * @param float|int $step     步进值
      * @param int       $lazyTime 延迟时间（秒）
      *
      * @return int|false
      */
-    public function setInc(string $field, float $step = 1, int $lazyTime = 0)
+    public function setInc(string $field, float|int $step = 1, int $lazyTime = 0)
     {
         return $this->inc($field, $step, $lazyTime)->update();
     }
@@ -422,13 +422,13 @@ class Query extends BaseQuery
     /**
      * 字段值减少（支持延迟写入）
      *
-     * @param string    $field 字段名
-     * @param float     $step  步进值
+     * @param string    $field    字段名
+     * @param float|int $step     步进值
      * @param int       $lazyTime 延迟时间（秒）
      *
      * @return int|false
      */
-    public function setDec(string $field, float $step = 1, int $lazyTime = 0)
+    public function setDec(string $field, float|int $step = 1, int $lazyTime = 0)
     {
         return $this->dec($field, $step, $lazyTime)->update();
     }

--- a/src/helper.php
+++ b/src/helper.php
@@ -38,14 +38,14 @@ if (!function_exists('raw')) {
 }
 
 if (!function_exists('inc')) {
-    function inc(float $step = 1, int $lazyTime = 0): Express
+    function inc(float|int $step = 1, int $lazyTime = 0): Express
     {
         return new Express('+', $step, $lazyTime);
     }
 }
 
 if (!function_exists('dec')) {
-    function dec(float $step = 1, int $lazyTime = 0): Express
+    function dec(float|int $step = 1, int $lazyTime = 0): Express
     {
         return new Express('-', $step, $lazyTime);
     }


### PR DESCRIPTION
步进值支持传入 int（ThinkPHP 高级交流群反馈 Redis::incrBy() 的参数 2 仅支持 int 类型，目前传入的是 float）
![086cd871d2de5062583c1be7aae5abd0](https://github.com/user-attachments/assets/4ec4551a-92e2-4d80-ac45-14d5c7467707)
