### PR TITLE
fix: 自定义某个时间字段格式失效

### DIFF
--- a/src/model/concern/Attribute.php
+++ b/src/model/concern/Attribute.php
@@ -245,8 +245,12 @@ trait Attribute
             'object'         => empty($value) ? new \stdClass() : (is_string($value) ? json_decode($value) : json_decode(json_encode($value, JSON_FORCE_OBJECT))),
             'json'           => $typeTransform(Json::class, $value, $this),
             'date'           => $typeTransform(Date::class, $value, $this),
-            'datetime'       => $typeTransform(DateTime::class, $value, $this),
-            'timestamp'      => $typeTransform(DateTime::class, $value, $this),
+            'datetime','timestamp'      => (function() use ($value, $param, $typeTransform){
+                if (!empty($param)){
+                    $this->setDateFormat($param);
+                }
+                return $typeTransform(DateTime::class, $value, $this);
+            })(),
             default          => $typeTransform($type, $value, $this),
         };
     }


### PR DESCRIPTION
'birthday'  =>  'timestamp:Y/m/d',
用冒号分割或数组形式的
![image](https://github.com/user-attachments/assets/10f7b1a0-0855-47f4-b2f1-8c06c478f45f)
