### PR TITLE
解决DbConnect.php第40行autoInc的bug

### DIFF
--- a/src/db/Mongo.php
+++ b/src/db/Mongo.php
@@ -755,4 +755,35 @@ class Mongo extends BaseQuery
 
         return $fieldType[$field] ?? null;
     }
+
+    /**
+     * 获取字段类型
+     * 
+     * @return array
+     */
+    public function getType()
+    {
+        return $this->getFieldsType();
+    }
+
+    /**
+     * 获取自增主键
+     * 
+     * @return string
+     */
+    public function getAutoInc()
+    {
+        return '';
+    }
+
+    /**
+     * 设置自增主键
+     * 
+     * @param string $autoInc
+     * @return static
+     */
+    public function autoInc(?string $autoInc)
+    {
+        return $this;
+    }
 }


### PR DESCRIPTION
使用mongo驱动时
`think\model\concern\DbConnect`
第40行需要调用mongo的自动递增主键的方法,会报方法不存在的错误, 补充了这3个对应方法解决此bug