### PR TITLE
修复mongo的write transform错误

### DIFF
--- a/src/model/concern/Attribute.php
+++ b/src/model/concern/Attribute.php
@@ -521,7 +521,10 @@ trait Attribute
             $value = $this->$method($value, $data);
         } else {
             // 类型转换
-            $value = $this->writeTransform($value, $this->getFields($name));
+            $type = $this->getFields($name);
+            if (isset($type)) {
+                $value = $this->writeTransform($value, $type);
+            }
         }
 
         if ($value instanceof Express) {

--- a/src/model/concern/DbConnect.php
+++ b/src/model/concern/DbConnect.php
@@ -104,7 +104,7 @@ trait DbConnect
         }
 
         if ($field) {
-            return $schema[$field] ?? 'string';
+            return $schema[$field] ?? null;
         }
 
         return $schema;


### PR DESCRIPTION
1. DbConnect.php的getFields如果字段未配置,默认返回null
2. Attribute.php writeTransform转换前预先判断是否有明确的类型,即非null才执行类型转换

主要是针对mongo数据库会出现bug的修复