### PR TITLE
修复mongo无法自动写入时间问题

### DIFF
--- a/src/model/concern/AutoWriteData.php
+++ b/src/model/concern/AutoWriteData.php
@@ -72,7 +72,7 @@ trait AutoWriteData
             }
 
             foreach ($dateTimeFields as $field) {
-                if (is_string($field) && in_array($field, $allow)) {
+                if (is_string($field) && (empty($allow) || in_array($field, $allow))) {
                     $data[$field] = $this->getDateTime($field);
                     $this->setData($field, $this->readTransform($data[$field], $this->getFields($field)));
                 }
@@ -88,7 +88,7 @@ trait AutoWriteData
      */
     protected function getDateTime(string $field)
     {
-        $type = $this->getFields($field);
+        $type = $this->getFields($field) ?? 'string';
         if (in_array($type, ['int', 'integer'])) {
             return time();
         } elseif (is_subclass_of($type, Typeable::class)) {


### PR DESCRIPTION
1. mongo的默认allow是空数组,如果不判断就不会添加对应的时间
2. getFields在mongo里默认返回null,会造成str_contains报错,所以改为`$type=$this->getFields($field) ?? 'string';`