### PR TITLE
修正中间表缺失表名

### DIFF
--- a/src/model/Pivot.php
+++ b/src/model/Pivot.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace think\model;
 
+use think\helper\Str;
 use think\Model;
 
 /**
@@ -26,6 +27,11 @@ class Pivot extends Model
      * @var Model
      */
     public $parent;
+
+    /**
+     * 中间表名称.
+     * @var string
+     */
     protected $pivotName;
 
     /**
@@ -56,8 +62,8 @@ class Pivot extends Model
      */
     protected function init() 
     {
-        if (is_null($this->getOption('name'))) {
-            $this->setOption('name', $this->pivotName);
+        if (null === $this->getOption('name')) {
+            $this->setOption('name', $this->pivotName ?: Str::snake(class_basename(static::class)));
         }
     }
 


### PR DESCRIPTION
错误信息：

```
SQLSTATE[42000]: Syntax error or access violation: 1103 Incorrect table name ''
```

模型：
```php
<?php
namespace app\model;

/**
 * 消息类型接收人
 */
class MessageTypeUser extends \think\model\Pivot
{
    // 模型参数
    protected function getOptions(): array
    {
        return [
            'autoWriteTimestamp' => true,
        ];
    }

    /**
     * 用户
     * @return \think\model\relation\BelongsTo
     */
    public function user(): \think\model\relation\BelongsTo
    {
        return $this->belongsTo(User::class, 'user_id');
    }

    /**
     * 类型
     * @return \think\model\relation\BelongsTo
     */
    public function type(): \think\model\relation\BelongsTo
    {
        return $this->belongsTo(MessageType::class, 'type_id');
    }
}
```

查询：
```php
\app\model\MessageTypeUser::where('merchant_id', 0)->select()
```