### PR TITLE
修复mongo游标查询问题

### DIFF
--- a/src/db/Mongo.php
+++ b/src/db/Mongo.php
@@ -541,11 +541,21 @@ class Mongo extends BaseQuery
      *
      * @return Cursor
      */
+    public function cursor(): Cursor
+    {
+        return $this->getCursor();
+    }
+    
+    /**
+     * 执行查询但只返回Cursor对象
+     *
+     * @return Cursor
+     */
     public function getCursor(): Cursor
     {
         $this->parseOptions();
 
-        return $this->connection->getCursor($this);
+        return $this->connection->cursor($this);
     }
 
     /**


### PR DESCRIPTION
1. 修复->cursor()查询报cursor方法未找到的报错
2. getCursor方法应该调用connection->cursor($this), 如果调用getCursor会报参数缺少mongoQuery