### PR TITLE
修复chunk查询中断问题

### DIFF
--- a/src/db/Mongo.php
+++ b/src/db/Mongo.php
@@ -637,6 +637,9 @@ class Mongo extends BaseQuery
                 [$alias, $key] = explode('.', $column);
             } else {
                 $key = $column;
+                if ($key == '_id' && $this->connection->getConfig('pk_convert_id')) {
+                    $key = 'id';
+                }
             }
         }
 


### PR DESCRIPTION
当没有指定column时 取值是_id, 而且开启了`pk_convert_id`时，
`$lastId = is_array($end) ? $end[$key] : $end->getData($key);`将会找不到值，$lastId=null，进而导致后续的query有问题，就中断退出了