### PR TITLE
优化 JSON 字段解析效率

### DIFF
--- a/src/model/type/Json.php
+++ b/src/model/type/Json.php
@@ -20,12 +20,14 @@ class Json implements Typeable
 
     public function data($data, ?bool $assoc)
     {
-        if (is_string($data) && json_validate($data)) {
-            $data = json_decode($data, $assoc);
-        } elseif (empty($data)) {
-            $data = [];
+        if (is_string($data)) {
+            $this->data = json_decode($data, $assoc);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                $this->data = [$data];
+            }
+            return;
         }
-        $this->data = is_string($data) ? [$data] : $data;
+        $this->data = empty($data) ? [] : $data;
     }
 
     public function value()


### PR DESCRIPTION
在 [json_validate](https://www.php.net/json_validate) 函数文档中提到：
> 在 [json_decode()](https://www.php.net/manual/zh/function.json-decode.php) 之前调用 json_validate() 将不必要地解析字符串两次， 因为 [json_decode()](https://www.php.net/manual/zh/function.json-decode.php) 在解码过程中隐式地执行验证
> json_validate() 只有在解码后的 JSON 内容不会立即使用，但需要知道字符串是否包含有效的 JSON 时才有用。

本 PR 修改了 JSON 格式校验的方式，减少解析次数。