### PR TITLE
常驻内存框架下，通过作用域查询，会导致model中的query的model关联自身，导致内存无法释放。

### DIFF
--- a/src/db/concern/ModelRelationQuery.php
+++ b/src/db/concern/ModelRelationQuery.php
@@ -163,6 +163,7 @@ trait ModelRelationQuery
                 [$call, $args] = $val;
                 call_user_func_array($call, $args);
             }
+            $this->options['scope'] = [];
         }
 
         return $this;


### PR DESCRIPTION
常驻内存框架下，通过作用域查询，会导致model中的query的model关联自身，导致内存无法释放。