### PR TITLE
fix: 实体模型调用静态方法时，支持识别对应模型的自定义静态方法，而不是写死几个方法

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -40,21 +40,14 @@ abstract class Entity implements JsonSerializable, ArrayAccess, Arrayable, Jsona
         $this->initWeakMap();
 
         // 获取实体模型参数
-        $baseOptions = $this->getBaseOptions();
-        $options     = $this->getOptions();
-        
-        foreach (['viewMapping', 'autoMapping'] as $item) {
-            $options[$item] = array_merge($baseOptions[$item] ?? [], $options[$item] ?? []);
-        }
-
-        $options = array_merge($baseOptions, $options);
+        $options = $this->getOptions();
 
         if (is_null($model)) {
             $class = !empty($options['modelClass']) ? $options['modelClass'] : str_replace('\\entity\\', '\\model\\', static::class);
             $model = new $class();
+            $model->entity($this);
         }
 
-        $model->entity($this);
         self::$weakMap[$this] = [
             'model' =>  $model,
         ];
@@ -72,17 +65,7 @@ abstract class Entity implements JsonSerializable, ArrayAccess, Arrayable, Jsona
     }
 
     /**
-     * 定义实体模型的基础配置参数.
-     *
-     * @return array
-     */
-    protected function getBaseOptions(): array
-    {
-        return [];
-    }
-
-    /**
-     * 定义实体模型相关配置参数.
+     * 在实体模型中定义 返回相关配置参数.
      *
      * @return array
      */
@@ -134,12 +117,11 @@ abstract class Entity implements JsonSerializable, ArrayAccess, Arrayable, Jsona
      * 创建新的实例.
      *
      * @param Model $model 模型连接对象
-     * @param array $options 查询参数
      */
-    public function newInstance(?Model $model, array $options = [])
+    public function newInstance(?Model $model)
     {
         $entity = new static();
-        return $entity->setModel($model, $options);
+        return $entity->setModel($model);
     }
 
     /**
@@ -326,10 +308,15 @@ abstract class Entity implements JsonSerializable, ArrayAccess, Arrayable, Jsona
     public static function __callStatic($method, $args)
     {
         $entity = new static();
-        if (in_array($method, ['destroy', 'create', 'update', 'saveAll'])) {
-            // 调用model的静态方法
-            $db = $entity->model();
-        } else {
+        $modelClass = get_class($entity->model());
+        
+        $staticMethods = (new \ReflectionClass($modelClass))->getMethods(\ReflectionMethod::IS_STATIC);
+		$staticPublicMethods = array_filter($staticMethods, fn($m) => $m->isPublic());
+
+        if (in_array($method, array_column($staticPublicMethods, 'name'))) {
+			// 调用model的静态方法
+			$db = $modelClass;
+		} else {
             // 调用Query类查询方法
             $db = $entity->model()->db();
         }

--- a/src/Model.php
+++ b/src/Model.php
@@ -20,6 +20,7 @@ use think\contract\Arrayable;
 use think\contract\Jsonable;
 use think\db\BaseQuery as Query;
 use think\db\Express;
+use think\exception\InvalidArgumentException;
 use think\exception\ValidateException;
 use think\model\Collection;
 use think\model\contract\Modelable;


### PR DESCRIPTION
原本实体模型的 __callStatic() 中是写死了对应模型的几个方法，只有这些方法支持对实体模型对应的模型调用，代码如下

```php
public static function __callStatic($method, $args)
{
    $entity = new static();
    if (in_array($method, ['destroy', 'create', 'update', 'saveAll'])) {
        // 调用model的静态方法
        $db = $entity->model();
    } else {
        // 调用Query类查询方法
        $db = $entity->model()->db();
    }

    return call_user_func_array([$db, $method], $args);
}
```

在升级orm 4的过程中，有时候无法避免在传统模型中存在一些公共的静态方法，因此实体模型应该支持对应模型公共静态方法的调用，而不是固定写死几个内置的方法
