### PR TITLE
fix: 允许通过实体模型调用对应模型的所有公共静态方法

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -326,9 +326,14 @@ abstract class Entity implements JsonSerializable, ArrayAccess, Arrayable, Jsona
     public static function __callStatic($method, $args)
     {
         $entity = new static();
-        if (in_array($method, ['destroy', 'create', 'update', 'saveAll'])) {
+        $modelClass = get_class($entity->model());
+
+        $staticMethods = (new \ReflectionClass($modelClass))->getMethods(\ReflectionMethod::IS_STATIC);
+		$staticPublicMethods = array_filter($staticMethods, fn($m) => $m->isPublic());
+
+        if (in_array($method, array_column($staticPublicMethods, 'name'))) {
             // 调用model的静态方法
-            $db = $entity->model();
+            $db = $modelClass;
         } else {
             // 调用Query类查询方法
             $db = $entity->model()->db();


### PR DESCRIPTION
原本实体模型的 __callStatic() 中是写死了对应模型的几个方法，只有这些方法支持对实体模型对应的模型调用，代码如下

```
public static function __callStatic($method, $args)
{
    $entity = new static();
    if (in_array($method, ['destroy', 'create', 'update', 'saveAll'])) {
        // 调用model的静态方法
        $db = $entity->model();
    } else {
        // 调用Query类查询方法
        $db = $entity->model()->db();
    }

    return call_user_func_array([$db, $method], $args);
}
```

在升级orm 4的过程中，有时候无法避免在传统模型中存在一些公共的静态方法，因此实体模型应该支持对应模型公共静态方法的调用，而不是固定写死几个内置的方法