### PR TITLE
fix(mongodb): 修复 DSN 构建时 authSource 参数缺失问题

### DIFF
--- a/src/db/connector/Mongo.php
+++ b/src/db/connector/Mongo.php
@@ -66,6 +66,8 @@ class Mongo extends Connection
         'username'        => '',
         // 密码
         'password'        => '',
+        // 验证数据库
+        'auth_source' => '',
         // 端口
         'hostport'        => '',
         // 连接dsn
@@ -169,6 +171,7 @@ class Mongo extends Connection
 
             if (empty($config['dsn'])) {
                 $config['dsn'] = 'mongodb://' . ($config['username'] ? "{$config['username']}" : '') . ($config['password'] ? ":{$config['password']}@" : '') . $config['hostname'] . ($config['hostport'] ? ":{$config['hostport']}" : '');
+                $config['dsn'] .= !empty($config['auth_source']) ? '/?authSource=' . $config['auth_source'] : '';
             }
 
             $startTime = microtime(true);


### PR DESCRIPTION
# 修复 MongoDB 开启安全认证后认证失败问题

## 问题描述

当 MongoDB 开启安全认证（`authorization: enabled`）后，使用 ThinkPHP 8.x + think-orm 4.x 自带的 MongoDB 连接器进行写入操作时，会出现以下错误：

```
Bulk write failed due to previous MongoDB\Driver\Exception\AuthenticationException: Authentication failed
```

## 问题原因

在 `vendor/topthink/think-orm/src/db/connector/Mongo.php` 文件中，构建 MongoDB DSN 连接字符串时，未添加 `authSource` 参数。当 MongoDB 开启安全认证后，需要指定认证数据库（authSource），否则会导致认证失败。

## 修复方案

通过以下两个改动来支持 MongoDB 安全认证：

1. **在配置数组中添加 `auth_source` 配置项**：允许用户通过配置文件指定认证数据库
2. **在构建 DSN 时添加 `authSource` 参数**：当配置了 `auth_source` 时，自动将其添加到连接字符串中

## 代码变更

### 修改文件
- `src/db/connector/Mongo.php`

### 变更 1：添加 `auth_source` 配置项

**位置**：配置数组 `$config` 中（约第 72 行）

**修改前：**
```php
protected $config = [
    // ...
    // 密码
    'password'        => '',
    // 端口
    'hostport'        => '',
    // ...
];
```

**修改后：**
```php
protected $config = [
    // ...
    // 密码
    'password'        => '',
    // 验证数据库
    'auth_source' => '',
    // 端口
    'hostport'        => '',
    // ...
];
```

### 变更 2：在 DSN 构建时添加 `authSource` 参数

**位置**：`connect()` 方法中（约第 169 行）

**修改前：**
```php
if (empty($config['dsn'])) {
    $config['dsn'] = 'mongodb://' . ($config['username'] ? "{$config['username']}" : '') . ($config['password'] ? ":{$config['password']}@" : '') . $config['hostname'] . ($config['hostport'] ? ":{$config['hostport']}" : '');
}
```

**修改后：**
```php
if (empty($config['dsn'])) {
    $config['dsn'] = 'mongodb://' . ($config['username'] ? "{$config['username']}" : '') . ($config['password'] ? ":{$config['password']}@" : '') . $config['hostname'] . ($config['hostport'] ? ":{$config['hostport']}" : '');
    $config['dsn'] .= !empty($config['auth_source']) ? '/?authSource=' . $config['auth_source'] : '';
}
```

## 使用说明

### 配置示例

在 `config/database.php` 中配置 MongoDB 连接时，可以添加 `auth_source` 参数：

```php
'mongo' => [
    // 数据库类型
    'type'        => 'mongo',
    // 服务器地址
    'hostname'    => env('MONGO_HOST', '127.0.0.1'),
    // 数据库名
    'database'    => env('MONGO_DATABASE', 'test'),
    // 用户名
    'username'    => env('MONGO_USERNAME', 'admin'),
    // 密码
    'password'    => env('MONGO_PASSWORD', 'password'),
    // 验证数据库（认证数据库名，通常与 database 相同或为 'admin'）
    'auth_source' => env('MONGO_AUTH_SOURCE', 'admin'),
    // 端口
    'hostport'    => env('MONGO_PORT', '27017'),
    // 数据库表前缀
    'prefix'      => env('MONGO_PREFIX', null),
    // 是否_id转换为id
    'pk_convert_id' => true,
],
```

### 生成的 DSN 示例

配置了 `auth_source` 后，生成的 DSN 将类似：
```
mongodb://admin:password@127.0.0.1:27017/?authSource=admin
```

未配置 `auth_source` 时，生成的 DSN 保持原有格式：
```
mongodb://admin:password@127.0.0.1:27017
```

## 影响范围

- **影响功能**：MongoDB 数据库连接（仅在配置了 `auth_source` 时生效）
- **兼容性**：
  - ✅ **完全向后兼容**：未配置 `auth_source` 时，行为与之前完全一致
  - ✅ **可选配置**：`auth_source` 为空字符串时，不添加 `authSource` 参数
  - ✅ **不影响手动 DSN**：如果手动配置了完整的 `dsn`，不会触发自动构建逻辑

## 测试说明

### 测试环境
- MongoDB 版本：8.2.3
- PHP 版本：>= 8.1
- ThinkPHP：8.0
- think-orm：^4.0

### 测试场景

1. **MongoDB 未开启认证**
   - 配置：不设置 `auth_source` 或设置为空字符串
   - 预期：连接正常，功能不受影响
   - DSN 格式：`mongodb://hostname:port`

2. **MongoDB 开启认证，配置了 `auth_source`**
   - 配置：设置 `auth_source` 为认证数据库名（如 `admin` 或数据库名）
   - 预期：连接成功，可以进行读写操作
   - DSN 格式：`mongodb://username:password@hostname:port/?authSource=数据库名`

3. **手动配置完整 DSN**
   - 配置：在配置中直接设置 `dsn` 参数
   - 预期：使用手动配置的 DSN，不受此修改影响

4. **未配置 `auth_source`（向后兼容测试）**
   - 配置：不设置 `auth_source` 或设置为空字符串
   - 预期：DSN 不包含 `authSource` 参数，保持原有行为

### 常见认证数据库配置

- **用户创建在 `admin` 数据库**：`auth_source => 'admin'`
- **用户创建在业务数据库**：`auth_source => 'your_database_name'`
- **用户创建在数据库与业务数据库相同**：`auth_source => env('MONGO_DATABASE')`

## 相关 Issue

如存在相关 Issue，请在此处引用：
- Issue #xxx: MongoDB 开启认证后认证失败

## 检查清单

- [x] 代码符合项目代码规范
- [x] 向后兼容性良好（未配置时不影响现有功能）
- [x] 代码逻辑清晰（仅在配置了 `auth_source` 时才添加参数）
- [x] 不影响其他功能
- [x] 配置项命名规范（使用下划线命名 `auth_source`）

## 总结

此修复通过添加 `auth_source` 配置项，使得 ThinkPHP 的 MongoDB 连接器能够支持开启安全认证的 MongoDB 数据库。修复方案简洁、向后兼容，用户可以根据自己的 MongoDB 认证配置灵活设置 `auth_source` 参数。
