### PR TITLE
Cast total to int before returning in Paginator

### DIFF
--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -266,7 +266,7 @@ abstract class Paginator implements ArrayAccess, Countable, IteratorAggregate, J
             throw new DomainException('not support total');
         }
 
-        return $this->total;
+        return (int) $this->total;
     }
 
     /**


### PR DESCRIPTION
think\Paginator::total(): Return value must be of type int, null returned