### PR TITLE
修复 `find => force => save` 这个流程下`update_time` 不更新的问题

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -450,7 +450,7 @@ abstract class Model implements JsonSerializable, ArrayAccess, Arrayable, Jsonab
                 unset($data[$name]);
             } elseif ($val instanceof Collection || (!empty($allow) && !in_array($name, $allow))) {
                 unset($data[$name]);
-            } elseif ($isUpdate && !$this->isForce() && $this->isNotRequireUpdate($name, $val, $origin)) {
+            } elseif ($isUpdate && (!$this->isForce() || $name == $this->getOption('updateTime')) && $this->isNotRequireUpdate($name, $val, $origin)) {
                 unset($data[$name]);
             } else {
                 $val = $this->setAttrOfWith($name, $val);


### PR DESCRIPTION
```php
$user = User::find(1);
$res = $user->force()->save(['name' => '小明' . time()]);
//结果：表中`update_time`不更新。
```

原因分析，find查询出表中的所有字段，包含`update_time`。
当调用->force()后，更新的时候不检查是否需要更新并unset()未改变字段。
把查询出来的`update_time`值原样写回去。
在`autoDateTime`方法中，判断当保存的数据中`update_time`字段空才会把它设置为当前时间