### PR TITLE
修复当实体模型命名空间只有一层时导致的重复初始化

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -50,7 +50,11 @@ abstract class Entity implements JsonSerializable, ArrayAccess, Arrayable, Jsona
         $options = array_merge($baseOptions, $options);
 
         if (is_null($model)) {
-            $class = !empty($options['modelClass']) ? $options['modelClass'] : str_replace('\\entity\\', '\\model\\', static::class);
+            if (empty($options['modelClass'])) {
+                $class = str_replace(['\\entity\\', 'entity\\'], ['\\model\\', 'model\\'], static::class);
+            } else {
+                $class = $options['modelClass'];
+            }
             $model = new $class();
         }
 


### PR DESCRIPTION
#846 